### PR TITLE
RPC in-flight recovery across a tb-core rollout

### DIFF
--- a/application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql
+++ b/application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql
@@ -1,0 +1,21 @@
+--
+-- Copyright © 2016-2026 The Thingsboard Authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- RPC REQUEST ID ADDITION START
+
+ALTER TABLE rpc ADD COLUMN IF NOT EXISTS request_id integer;
+
+-- RPC REQUEST ID ADDITION END

--- a/application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql
+++ b/application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql
@@ -20,6 +20,7 @@ ALTER TABLE rpc ADD COLUMN IF NOT EXISTS request_id integer;
 
 ALTER TABLE rpc ADD COLUMN IF NOT EXISTS oneway boolean;
 
+-- keep in sync with dao/src/main/resources/sql/schema-entities-idx.sql (idx_rpc_in_flight)
 CREATE INDEX IF NOT EXISTS idx_rpc_in_flight ON rpc (tenant_id, device_id)
     WHERE status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false);
 

--- a/application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql
+++ b/application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql
@@ -20,7 +20,6 @@ ALTER TABLE rpc ADD COLUMN IF NOT EXISTS request_id integer;
 
 ALTER TABLE rpc ADD COLUMN IF NOT EXISTS oneway boolean;
 
--- keep in sync with dao/src/main/resources/sql/schema-entities-idx.sql (idx_rpc_in_flight)
 CREATE INDEX IF NOT EXISTS idx_rpc_in_flight ON rpc (tenant_id, device_id)
     WHERE status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false);
 

--- a/application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql
+++ b/application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql
@@ -21,6 +21,6 @@ ALTER TABLE rpc ADD COLUMN IF NOT EXISTS request_id integer;
 ALTER TABLE rpc ADD COLUMN IF NOT EXISTS oneway boolean;
 
 CREATE INDEX IF NOT EXISTS idx_rpc_in_flight ON rpc (tenant_id, device_id)
-    WHERE status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false);
+    WHERE status IN ('QUEUED','SENT','TIMEOUT') OR (status = 'DELIVERED' AND oneway = false);
 
 -- RPC REQUEST ID ADDITION END

--- a/application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql
+++ b/application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql
@@ -18,4 +18,9 @@
 
 ALTER TABLE rpc ADD COLUMN IF NOT EXISTS request_id integer;
 
+ALTER TABLE rpc ADD COLUMN IF NOT EXISTS oneway boolean;
+
+CREATE INDEX IF NOT EXISTS idx_rpc_in_flight ON rpc (tenant_id, device_id)
+    WHERE status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false);
+
 -- RPC REQUEST ID ADDITION END

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -115,8 +115,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcessor {
 
-    // Shared with V4_3_1_4Migration.LEGACY_CLOSE_RESPONSE so a row closed by the one-time backfill reads
-    // identically to one closed live by this actor on reload.
     public static final String LEGACY_UNTRACKED_MESSAGE =
             "This RPC was no longer tracked by the platform after a restart and could not reach a terminal state " +
                     "on its own. It was left stuck in a non-terminal state (SENT or DELIVERED) and has now been " +
@@ -315,9 +313,6 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         new PageDataIterable<>(link -> systemContext.getTbRpcService()
                 .findInFlightForReload(tenantId, deviceId, link), 1024)
                 .forEach(inFlight::add);
-        // createdTime == submission order; requestId (rpcSeq at creation) breaks same-millisecond ties
-        // so the reload (and thus the sequential re-publish) order is deterministic. Legacy rows have a
-        // null requestId and sort last on a tie — they predate the id scheme, so their order is best-effort.
         inFlight.sort(Comparator.comparingLong(Rpc::getCreatedTime)
                 .thenComparing(Rpc::getRequestId, Comparator.nullsLast(Comparator.naturalOrder())));
         return inFlight;
@@ -331,9 +326,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         }
         RpcStatus status = rpc.getStatus();
         if (msg.isOneway() && status == RpcStatus.DELIVERED) {
-            return; // one-way DELIVERED is the terminal success state — leave untouched, never re-publish.
-            // One-way SENT falls through to reload/re-arm/re-publish. SENT only exists for QoS 1
-            // (QoS 0 goes QUEUED->DELIVERED on write), so this re-publish auto-scopes to QoS 1.
+            return;
         }
         // TODO(cleanup, post-4.3.1.4): transitional back-compat for rows created before request_id existed.
         // This SENT/DELIVERED close-guard and the QUEUED fresh-id fallback below go dead once no rpc row has
@@ -341,9 +334,6 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         // this guard / the 4.3.1.4 migration drain them). Safe to delete in a later release; consider making
         // rpc.request_id NOT NULL then. (The msg == null guard above is permanent.)
         if (rpc.getRequestId() == null && (status == RpcStatus.SENT || status == RpcStatus.DELIVERED)) {
-            // Untrackable legacy row (one-way DELIVERED already returned above; the reload query now also excludes
-            // null-oneway DELIVERED, so this is reached mainly by legacy SENT stragglers). Close it — re-publishing
-            // would push a stale command to the device. Past expiry -> EXPIRED, otherwise -> FAILED.
             rpc.setStatus(rpc.getExpirationTime() < System.currentTimeMillis() ? RpcStatus.EXPIRED : RpcStatus.FAILED);
             rpc.setResponse(LEGACY_UNTRACKED_RESPONSE);
             systemContext.getTbRpcService().update(tenantId, rpc);
@@ -356,8 +346,6 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
             return;
         }
         Integer persistedId = rpc.getRequestId();
-        // rpcSeq was already advanced past every persisted id in init(), so a legacy row (null id) draws a
-        // fresh id that cannot collide with a persisted id reloaded in the same batch.
         int requestId = persistedId != null ? persistedId : rpcSeq++;
         boolean sent = status != RpcStatus.QUEUED;
         boolean delivered = status == RpcStatus.DELIVERED;
@@ -1112,8 +1100,6 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
 
     void init(TbActorCtx ctx) {
         List<Rpc> inFlight = loadInFlightRpcs();
-        // Advance the counter past every persisted id BEFORE restoring, so a legacy row (null id) that draws
-        // rpcSeq++ during restore cannot collide with a persisted id reloaded in the same batch.
         int maxPersistedId = inFlight.stream().map(Rpc::getRequestId).filter(Objects::nonNull)
                 .mapToInt(Integer::intValue).max().orElse(-1);
         rpcSeq = Math.max(rpcSeq, maxPersistedId + 1);

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -301,12 +301,10 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
                 .build();
     }
 
-    private static final List<RpcStatus> IN_FLIGHT_STATUSES = List.of(RpcStatus.QUEUED, RpcStatus.SENT, RpcStatus.DELIVERED);
-
     private List<Rpc> loadInFlightRpcs() {
         List<Rpc> inFlight = new ArrayList<>();
         new PageDataIterable<>(link -> systemContext.getTbRpcService()
-                .findAllByDeviceIdAndStatusIn(tenantId, deviceId, IN_FLIGHT_STATUSES, link), 1024)
+                .findInFlightForReload(tenantId, deviceId, link), 1024)
                 .forEach(inFlight::add);
         // createdTime == submission order; requestId (rpcSeq at creation) breaks same-millisecond ties
         // so the reload (and thus the sequential re-publish) order is deterministic. Legacy rows have a

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -115,10 +115,14 @@ import java.util.stream.Collectors;
 @Slf4j
 public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcessor {
 
-    private static final JsonNode LEGACY_UNTRACKED_RESPONSE = JacksonUtil.newObjectNode().put("error",
+    // Shared with V4_3_1_4Migration.LEGACY_CLOSE_RESPONSE so a row closed by the one-time backfill reads
+    // identically to one closed live by this actor on reload.
+    public static final String LEGACY_UNTRACKED_MESSAGE =
             "This RPC was no longer tracked by the platform after a restart and could not reach a terminal state " +
                     "on its own. It was left stuck in a non-terminal state (SENT or DELIVERED) and has now been " +
-                    "closed automatically.");
+                    "closed automatically.";
+
+    private static final JsonNode LEGACY_UNTRACKED_RESPONSE = JacksonUtil.newObjectNode().put("error", LEGACY_UNTRACKED_MESSAGE);
 
     final TenantId tenantId;
     final DeviceId deviceId;

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -97,6 +97,7 @@ import org.thingsboard.server.service.transport.msg.TransportToDeviceActorMsgWra
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -295,6 +296,64 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
                 .setOneway(request.isOneway())
                 .setPersisted(request.isPersisted())
                 .build();
+    }
+
+    private ToDeviceRpcRequestMsg createToDeviceRpcRequestMsg(ToDeviceRpcRequest request, int requestId) {
+        ToDeviceRpcRequestBody body = request.getBody();
+        return ToDeviceRpcRequestMsg.newBuilder()
+                .setRequestId(requestId)
+                .setMethodName(body.getMethod())
+                .setParams(body.getParams())
+                .setExpirationTime(request.getExpirationTime())
+                .setRequestIdMSB(request.getId().getMostSignificantBits())
+                .setRequestIdLSB(request.getId().getLeastSignificantBits())
+                .setOneway(request.isOneway())
+                .setPersisted(request.isPersisted())
+                .build();
+    }
+
+    private List<Rpc> loadInFlightRpcs() {
+        List<Rpc> inFlight = new ArrayList<>();
+        for (RpcStatus status : List.of(RpcStatus.QUEUED, RpcStatus.SENT, RpcStatus.DELIVERED)) {
+            PageLink pageLink = new PageLink(1024, 0, null, new SortOrder("createdTime"));
+            PageData<Rpc> pageData;
+            do {
+                pageData = systemContext.getTbRpcService().findAllByDeviceIdAndStatus(tenantId, deviceId, status, pageLink);
+                inFlight.addAll(pageData.getData());
+                pageLink = pageLink.nextPageLink();
+            } while (pageData.hasNext());
+        }
+        inFlight.sort(Comparator.comparingLong(Rpc::getCreatedTime)); // == rpcSeq/submission order
+        return inFlight;
+    }
+
+    private void restorePendingRpc(TbActorCtx ctx, Rpc rpc) {
+        ToDeviceRpcRequest msg = JacksonUtil.convertValue(rpc.getRequest(), ToDeviceRpcRequest.class);
+        long timeout = rpc.getExpirationTime() - System.currentTimeMillis();
+        if (timeout <= 0) {
+            rpc.setStatus(RpcStatus.EXPIRED);
+            systemContext.getTbRpcService().update(tenantId, rpc);
+            return;
+        }
+        RpcStatus status = rpc.getStatus();
+        if (msg.isOneway() && status != RpcStatus.QUEUED) {
+            return; // one-way is terminal once sent/delivered — only redeliver QUEUED one-way
+        }
+        Integer persistedId = rpc.getRequestId();
+        int requestId = persistedId != null ? persistedId : rpcSeq++; // legacy rows (null): fresh id, today's behavior
+        boolean sent = status != RpcStatus.QUEUED;
+        boolean delivered = status == RpcStatus.DELIVERED;
+        registerRestoredRpc(ctx, msg, requestId, sent, delivered, timeout, rpc.getCreatedTime());
+    }
+
+    private void registerRestoredRpc(TbActorCtx ctx, ToDeviceRpcRequest msg, int requestId,
+                                      boolean sent, boolean delivered, long timeout, long createdTime) {
+        ToDeviceRpcRequestActorMsg actorMsg = new ToDeviceRpcRequestActorMsg(systemContext.getServiceId(), msg);
+        ToDeviceRpcRequestMetadata md = new ToDeviceRpcRequestMetadata(actorMsg, sent, createdTime);
+        md.setDelivered(delivered);
+        toDeviceRpcPendingMap.put(requestId, md);
+        DeviceActorServerSideRpcTimeoutMsg timeoutMsg = new DeviceActorServerSideRpcTimeoutMsg(requestId, timeout);
+        scheduleMsgWithDelay(ctx, timeoutMsg, timeoutMsg.getTimeout());
     }
 
     void processRpcResponsesFromEdge(FromDeviceRpcResponseActorMsg responseMsg) {
@@ -654,7 +713,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         }
     }
 
-    private void processRpcResponses(SessionInfoProto sessionInfo, ToDeviceRpcResponseMsg responseMsg) {
+    void processRpcResponses(SessionInfoProto sessionInfo, ToDeviceRpcResponseMsg responseMsg) {
         UUID sessionId = getSessionId(sessionInfo);
         log.debug("[{}][{}] Processing RPC command response: {}", deviceId, sessionId, responseMsg);
         int requestId = responseMsg.getRequestId();
@@ -1036,24 +1095,9 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
     }
 
     void init(TbActorCtx ctx) {
-        PageLink pageLink = new PageLink(1024, 0, null, new SortOrder("createdTime"));
-        PageData<Rpc> pageData;
-        do {
-            pageData = systemContext.getTbRpcService().findAllByDeviceIdAndStatus(tenantId, deviceId, RpcStatus.QUEUED, pageLink);
-            pageData.getData().forEach(rpc -> {
-                ToDeviceRpcRequest msg = JacksonUtil.convertValue(rpc.getRequest(), ToDeviceRpcRequest.class);
-                long timeout = rpc.getExpirationTime() - System.currentTimeMillis();
-                if (timeout <= 0) {
-                    rpc.setStatus(RpcStatus.EXPIRED);
-                    systemContext.getTbRpcService().update(tenantId, rpc);
-                } else {
-                    registerPendingRpcRequest(ctx, new ToDeviceRpcRequestActorMsg(systemContext.getServiceId(), msg), false, createToDeviceRpcRequestMsg(msg), timeout, rpc.getCreatedTime());
-                }
-            });
-            if (pageData.hasNext()) {
-                pageLink = pageLink.nextPageLink();
-            }
-        } while (pageData.hasNext());
+        for (Rpc rpc : loadInFlightRpcs()) {
+            restorePendingRpc(ctx, rpc);
+        }
     }
 
     void checkSessionsTimeout() {

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -248,7 +248,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
             log.debug("[{}] RPC command response sent [{}][{}]!", deviceId, rpcId, requestId);
             systemContext.getTbCoreDeviceRpcService().processRpcResponseFromDeviceActor(new FromDeviceRpcResponse(rpcId, null, null));
         } else {
-            registerPendingRpcRequest(context, msg, requestId, sent, false, timeout, createdTime);
+            registerPendingRpcRequest(context, msg, requestId, sent, timeout, createdTime);
         }
         String rpcSent = sent ? "sent!" : "NOT sent!";
         log.debug("[{}][{}][{}] RPC request is {}", deviceId, rpcId, requestId, rpcSent);
@@ -393,6 +393,10 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
                 }
             }
         }
+    }
+
+    private void registerPendingRpcRequest(TbActorCtx context, ToDeviceRpcRequestActorMsg actorMsg, int requestId, boolean sent, long timeout, long createdTime) {
+        registerPendingRpcRequest(context, actorMsg, requestId, sent, false, timeout, createdTime);
     }
 
     private void registerPendingRpcRequest(TbActorCtx context, ToDeviceRpcRequestActorMsg actorMsg, int requestId, boolean sent, boolean delivered, long timeout, long createdTime) {

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -298,20 +298,6 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
                 .build();
     }
 
-    private ToDeviceRpcRequestMsg createToDeviceRpcRequestMsg(ToDeviceRpcRequest request, int requestId) {
-        ToDeviceRpcRequestBody body = request.getBody();
-        return ToDeviceRpcRequestMsg.newBuilder()
-                .setRequestId(requestId)
-                .setMethodName(body.getMethod())
-                .setParams(body.getParams())
-                .setExpirationTime(request.getExpirationTime())
-                .setRequestIdMSB(request.getId().getMostSignificantBits())
-                .setRequestIdLSB(request.getId().getLeastSignificantBits())
-                .setOneway(request.isOneway())
-                .setPersisted(request.isPersisted())
-                .build();
-    }
-
     private List<Rpc> loadInFlightRpcs() {
         List<Rpc> inFlight = new ArrayList<>();
         for (RpcStatus status : List.of(RpcStatus.QUEUED, RpcStatus.SENT, RpcStatus.DELIVERED)) {
@@ -329,15 +315,15 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
 
     private void restorePendingRpc(TbActorCtx ctx, Rpc rpc) {
         ToDeviceRpcRequest msg = JacksonUtil.convertValue(rpc.getRequest(), ToDeviceRpcRequest.class);
+        RpcStatus status = rpc.getStatus();
+        if (msg.isOneway() && status != RpcStatus.QUEUED) {
+            return; // one-way SENT/DELIVERED is terminal for reload — leave the persisted row untouched
+        }
         long timeout = rpc.getExpirationTime() - System.currentTimeMillis();
         if (timeout <= 0) {
             rpc.setStatus(RpcStatus.EXPIRED);
             systemContext.getTbRpcService().update(tenantId, rpc);
             return;
-        }
-        RpcStatus status = rpc.getStatus();
-        if (msg.isOneway() && status != RpcStatus.QUEUED) {
-            return; // one-way is terminal once sent/delivered — only redeliver QUEUED one-way
         }
         Integer persistedId = rpc.getRequestId();
         int requestId = persistedId != null ? persistedId : rpcSeq++; // legacy rows (null): fresh id, today's behavior

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -115,6 +115,11 @@ import java.util.stream.Collectors;
 @Slf4j
 public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcessor {
 
+    private static final JsonNode LEGACY_UNTRACKED_RESPONSE = JacksonUtil.newObjectNode().put("error",
+            "This RPC was no longer tracked by the platform after a restart and could not reach a terminal state " +
+                    "on its own. It was left stuck in a non-terminal state (SENT or DELIVERED) and has now been " +
+                    "closed automatically.");
+
     final TenantId tenantId;
     final DeviceId deviceId;
     final LinkedHashMapRemoveEldest<UUID, SessionInfoMetaData> sessions;
@@ -325,6 +330,20 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
             return; // one-way DELIVERED is the terminal success state — leave untouched, never re-publish.
             // One-way SENT falls through to reload/re-arm/re-publish. SENT only exists for QoS 1
             // (QoS 0 goes QUEUED->DELIVERED on write), so this re-publish auto-scopes to QoS 1.
+        }
+        // TODO(cleanup, post-4.3.1.4): transitional back-compat for rows created before request_id existed.
+        // This SENT/DELIVERED close-guard and the QUEUED fresh-id fallback below go dead once no rpc row has
+        // request_id IS NULL (all cores upgraded AND every device with a legacy in-flight row reconnected once —
+        // this guard / the 4.3.1.4 migration drain them). Safe to delete in a later release; consider making
+        // rpc.request_id NOT NULL then. (The msg == null guard above is permanent.)
+        if (rpc.getRequestId() == null && (status == RpcStatus.SENT || status == RpcStatus.DELIVERED)) {
+            // Untrackable legacy row (one-way DELIVERED already returned above; the reload query now also excludes
+            // null-oneway DELIVERED, so this is reached mainly by legacy SENT stragglers). Close it — re-publishing
+            // would push a stale command to the device. Past expiry -> EXPIRED, otherwise -> FAILED.
+            rpc.setStatus(rpc.getExpirationTime() < System.currentTimeMillis() ? RpcStatus.EXPIRED : RpcStatus.FAILED);
+            rpc.setResponse(LEGACY_UNTRACKED_RESPONSE);
+            systemContext.getTbRpcService().update(tenantId, rpc);
+            return;
         }
         long timeout = rpc.getExpirationTime() - System.currentTimeMillis();
         if (timeout <= 0) {

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -325,6 +325,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
             return;
         }
         RpcStatus status = rpc.getStatus();
+        rpc.setOneway(msg.isOneway()); // authoritative request flag; the reloaded column may be NULL for legacy rows
         if (msg.isOneway() && status == RpcStatus.DELIVERED) {
             return;
         }

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -327,6 +327,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         }
         Integer persistedId = rpc.getRequestId();
         int requestId = persistedId != null ? persistedId : rpcSeq++; // legacy rows (null): fresh id, today's behavior
+        rpcSeq = Math.max(rpcSeq, requestId + 1); // keep the counter past every reloaded id
         boolean sent = status != RpcStatus.QUEUED;
         boolean delivered = status == RpcStatus.DELIVERED;
         registerRestoredRpc(ctx, msg, requestId, sent, delivered, timeout, rpc.getCreatedTime());

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -42,9 +42,7 @@ import org.thingsboard.server.common.data.id.RpcId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.kv.AttributeKey;
 import org.thingsboard.server.common.data.kv.AttributeKvEntry;
-import org.thingsboard.server.common.data.page.PageData;
-import org.thingsboard.server.common.data.page.PageLink;
-import org.thingsboard.server.common.data.page.SortOrder;
+import org.thingsboard.server.common.data.page.PageDataIterable;
 import org.thingsboard.server.common.data.relation.EntityRelation;
 import org.thingsboard.server.common.data.relation.RelationTypeGroup;
 import org.thingsboard.server.common.data.rpc.Rpc;
@@ -243,7 +241,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
             log.debug("[{}] RPC command response sent [{}][{}]!", deviceId, rpcId, requestId);
             systemContext.getTbCoreDeviceRpcService().processRpcResponseFromDeviceActor(new FromDeviceRpcResponse(rpcId, null, null));
         } else {
-            registerPendingRpcRequest(context, msg, sent, rpcRequest, timeout, createdTime);
+            registerPendingRpcRequest(context, msg, requestId, sent, false, timeout, createdTime);
         }
         String rpcSent = sent ? "sent!" : "NOT sent!";
         log.debug("[{}][{}][{}] RPC request is {}", deviceId, rpcId, requestId, rpcSent);
@@ -251,10 +249,14 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
 
     private boolean isSendNewRpcAvailable() {
         return switch (rpcSubmitStrategy) {
-            case SEQUENTIAL_ON_ACK_FROM_DEVICE -> toDeviceRpcPendingMap.values().stream().filter(md -> !md.isDelivered()).findAny().isEmpty();
+            case SEQUENTIAL_ON_ACK_FROM_DEVICE -> toDeviceRpcPendingMap.values().stream().filter(DeviceActorMessageProcessor::undelivered).findAny().isEmpty();
             case SEQUENTIAL_ON_RESPONSE_FROM_DEVICE -> toDeviceRpcPendingMap.isEmpty();
             default -> true;
         };
+    }
+
+    private static boolean undelivered(ToDeviceRpcRequestMetadata md) {
+        return !md.isDelivered();
     }
 
     private void createRpc(ToDeviceRpcRequest request, RpcStatus status, long createdTime, int requestId) {
@@ -298,18 +300,18 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
                 .build();
     }
 
+    private static final List<RpcStatus> IN_FLIGHT_STATUSES = List.of(RpcStatus.QUEUED, RpcStatus.SENT, RpcStatus.DELIVERED);
+
     private List<Rpc> loadInFlightRpcs() {
         List<Rpc> inFlight = new ArrayList<>();
-        for (RpcStatus status : List.of(RpcStatus.QUEUED, RpcStatus.SENT, RpcStatus.DELIVERED)) {
-            PageLink pageLink = new PageLink(1024, 0, null, new SortOrder("createdTime"));
-            PageData<Rpc> pageData;
-            do {
-                pageData = systemContext.getTbRpcService().findAllByDeviceIdAndStatus(tenantId, deviceId, status, pageLink);
-                inFlight.addAll(pageData.getData());
-                pageLink = pageLink.nextPageLink();
-            } while (pageData.hasNext());
-        }
-        inFlight.sort(Comparator.comparingLong(Rpc::getCreatedTime)); // == rpcSeq/submission order
+        new PageDataIterable<>(link -> systemContext.getTbRpcService()
+                .findAllByDeviceIdAndStatusIn(tenantId, deviceId, IN_FLIGHT_STATUSES, link), 1024)
+                .forEach(inFlight::add);
+        // createdTime == submission order; requestId (rpcSeq at creation) breaks same-millisecond ties
+        // so the reload (and thus the sequential re-publish) order is deterministic. Legacy rows have a
+        // null requestId and sort last on a tie — they predate the id scheme, so their order is best-effort.
+        inFlight.sort(Comparator.comparingLong(Rpc::getCreatedTime)
+                .thenComparing(Rpc::getRequestId, Comparator.nullsLast(Comparator.naturalOrder())));
         return inFlight;
     }
 
@@ -332,21 +334,13 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
             return;
         }
         Integer persistedId = rpc.getRequestId();
-        int requestId = persistedId != null ? persistedId : rpcSeq++; // legacy rows (null): fresh id, today's behavior
-        rpcSeq = Math.max(rpcSeq, requestId + 1); // keep the counter past every reloaded id
+        // rpcSeq was already advanced past every persisted id in init(), so a legacy row (null id) draws a
+        // fresh id that cannot collide with a persisted id reloaded in the same batch.
+        int requestId = persistedId != null ? persistedId : rpcSeq++;
         boolean sent = status != RpcStatus.QUEUED;
         boolean delivered = status == RpcStatus.DELIVERED;
-        registerRestoredRpc(ctx, msg, requestId, sent, delivered, timeout, rpc.getCreatedTime());
-    }
-
-    private void registerRestoredRpc(TbActorCtx ctx, ToDeviceRpcRequest msg, int requestId,
-                                      boolean sent, boolean delivered, long timeout, long createdTime) {
         ToDeviceRpcRequestActorMsg actorMsg = new ToDeviceRpcRequestActorMsg(systemContext.getServiceId(), msg);
-        ToDeviceRpcRequestMetadata md = new ToDeviceRpcRequestMetadata(actorMsg, sent, createdTime);
-        md.setDelivered(delivered);
-        toDeviceRpcPendingMap.put(requestId, md);
-        DeviceActorServerSideRpcTimeoutMsg timeoutMsg = new DeviceActorServerSideRpcTimeoutMsg(requestId, timeout);
-        scheduleMsgWithDelay(ctx, timeoutMsg, timeoutMsg.getTimeout());
+        registerPendingRpcRequest(ctx, actorMsg, requestId, sent, delivered, timeout, rpc.getCreatedTime());
     }
 
     void processRpcResponsesFromEdge(FromDeviceRpcResponseActorMsg responseMsg) {
@@ -391,11 +385,14 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         }
     }
 
-    private void registerPendingRpcRequest(TbActorCtx context, ToDeviceRpcRequestActorMsg msg, boolean sent, ToDeviceRpcRequestMsg rpcRequest, long timeout, long createdTime) {
-        int requestId = rpcRequest.getRequestId();
-        UUID rpcId = new UUID(rpcRequest.getRequestIdMSB(), rpcRequest.getRequestIdLSB());
+    private void registerPendingRpcRequest(TbActorCtx context, ToDeviceRpcRequestActorMsg actorMsg, int requestId, boolean sent, boolean delivered, long timeout, long createdTime) {
+        UUID rpcId = actorMsg.getMsg().getId();
         log.debug("[{}][{}][{}] Registering pending RPC request...", deviceId, rpcId, requestId);
-        toDeviceRpcPendingMap.put(requestId, new ToDeviceRpcRequestMetadata(msg, sent, createdTime));
+        ToDeviceRpcRequestMetadata md = new ToDeviceRpcRequestMetadata(actorMsg, sent, createdTime);
+        md.setDelivered(delivered);
+        if (toDeviceRpcPendingMap.put(requestId, md) != null) {
+            log.warn("[{}][{}][{}] Pending RPC map collision — previous entry was overwritten", deviceId, rpcId, requestId);
+        }
         DeviceActorServerSideRpcTimeoutMsg timeoutMsg = new DeviceActorServerSideRpcTimeoutMsg(requestId, timeout);
         scheduleMsgWithDelay(context, timeoutMsg, timeoutMsg.getTimeout());
     }
@@ -440,11 +437,11 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
             getFirstRpc().ifPresent(processPendingRpc(sessionId, nodeId, sentOneWayIds));
         } else if (sessionType == SessionType.ASYNC) {
             toDeviceRpcPendingMap.entrySet().stream()
-                    .filter(e -> !e.getValue().isDelivered())
+                    .filter(e -> undelivered(e.getValue()))
                     .forEach(processPendingRpc(sessionId, nodeId, sentOneWayIds));
         } else {
             toDeviceRpcPendingMap.entrySet().stream()
-                    .filter(e -> !e.getValue().isDelivered())
+                    .filter(e -> undelivered(e.getValue()))
                     .findFirst().ifPresent(processPendingRpc(sessionId, nodeId, sentOneWayIds));
         }
 
@@ -466,7 +463,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
                         return true;
                     });
         }
-        return toDeviceRpcPendingMap.entrySet().stream().filter(e -> !e.getValue().isDelivered()).findFirst();
+        return toDeviceRpcPendingMap.entrySet().stream().filter(e -> undelivered(e.getValue())).findFirst();
     }
 
     private void sendNextPendingRequest(UUID rpcId, int requestId, String logMessage) {
@@ -1092,7 +1089,13 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
     }
 
     void init(TbActorCtx ctx) {
-        for (Rpc rpc : loadInFlightRpcs()) {
+        List<Rpc> inFlight = loadInFlightRpcs();
+        // Advance the counter past every persisted id BEFORE restoring, so a legacy row (null id) that draws
+        // rpcSeq++ during restore cannot collide with a persisted id reloaded in the same batch.
+        int maxPersistedId = inFlight.stream().map(Rpc::getRequestId).filter(Objects::nonNull)
+                .mapToInt(Integer::intValue).max().orElse(-1);
+        rpcSeq = Math.max(rpcSeq, maxPersistedId + 1);
+        for (Rpc rpc : inFlight) {
             restorePendingRpc(ctx, rpc);
         }
     }

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -274,6 +274,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         rpc.setStatus(status);
         rpc.setAdditionalInfo(getAdditionalInfo(request));
         rpc.setRequestId(requestId);
+        rpc.setOneway(request.isOneway());
         return rpc;
     }
 

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -316,8 +316,10 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
     private void restorePendingRpc(TbActorCtx ctx, Rpc rpc) {
         ToDeviceRpcRequest msg = JacksonUtil.convertValue(rpc.getRequest(), ToDeviceRpcRequest.class);
         RpcStatus status = rpc.getStatus();
-        if (msg.isOneway() && status != RpcStatus.QUEUED) {
-            return; // one-way SENT/DELIVERED is terminal for reload — leave the persisted row untouched
+        if (msg.isOneway() && status == RpcStatus.DELIVERED) {
+            return; // one-way DELIVERED is the terminal success state — leave untouched, never re-publish.
+            // One-way SENT falls through to reload/re-arm/re-publish. SENT only exists for QoS 1
+            // (QoS 0 goes QUEUED->DELIVERED on write), so this re-publish auto-scopes to QoS 1.
         }
         long timeout = rpc.getExpirationTime() - System.currentTimeMillis();
         if (timeout <= 0) {

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -417,7 +417,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         }
     }
 
-    private void sendPendingRequests(UUID sessionId, String nodeId) {
+    void sendPendingRequests(UUID sessionId, String nodeId) {
         SessionType sessionType = getSessionType(sessionId);
         if (!toDeviceRpcPendingMap.isEmpty()) {
             log.debug("[{}] Pushing {} pending RPC messages to session: [{}]", deviceId, sessionId, toDeviceRpcPendingMap.size());
@@ -433,9 +433,13 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         if (rpcSequential) {
             getFirstRpc().ifPresent(processPendingRpc(sessionId, nodeId, sentOneWayIds));
         } else if (sessionType == SessionType.ASYNC) {
-            toDeviceRpcPendingMap.entrySet().forEach(processPendingRpc(sessionId, nodeId, sentOneWayIds));
+            toDeviceRpcPendingMap.entrySet().stream()
+                    .filter(e -> !e.getValue().isDelivered())
+                    .forEach(processPendingRpc(sessionId, nodeId, sentOneWayIds));
         } else {
-            toDeviceRpcPendingMap.entrySet().stream().findFirst().ifPresent(processPendingRpc(sessionId, nodeId, sentOneWayIds));
+            toDeviceRpcPendingMap.entrySet().stream()
+                    .filter(e -> !e.getValue().isDelivered())
+                    .findFirst().ifPresent(processPendingRpc(sessionId, nodeId, sentOneWayIds));
         }
 
         sentOneWayIds.stream().filter(id -> !toDeviceRpcPendingMap.get(id).getMsg().getMsg().isPersisted()).forEach(toDeviceRpcPendingMap::remove);

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -315,6 +315,10 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
 
     private void restorePendingRpc(TbActorCtx ctx, Rpc rpc) {
         ToDeviceRpcRequest msg = JacksonUtil.convertValue(rpc.getRequest(), ToDeviceRpcRequest.class);
+        if (msg == null) {
+            log.error("[{}] Failed to restore RPC request [{}]", deviceId, rpc.getId());
+            return;
+        }
         RpcStatus status = rpc.getStatus();
         if (msg.isOneway() && status == RpcStatus.DELIVERED) {
             return; // one-way DELIVERED is the terminal success state — leave untouched, never re-publish.

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -190,6 +190,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         UUID rpcId = request.getId();
         log.debug("[{}][{}] Received RPC request to process ...", deviceId, rpcId);
         ToDeviceRpcRequestMsg rpcRequest = createToDeviceRpcRequestMsg(request);
+        int requestId = rpcRequest.getRequestId();
 
         long createdTime = System.currentTimeMillis();
         long timeout = request.getExpirationTime() - createdTime;
@@ -198,15 +199,14 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         if (timeout <= 0) {
             log.debug("[{}][{}] Ignoring message due to exp time reached, {}", deviceId, rpcId, request.getExpirationTime());
             if (persisted) {
-                createRpc(request, RpcStatus.EXPIRED, createdTime);
+                createRpc(request, RpcStatus.EXPIRED, createdTime, requestId);
             }
             return;
         } else if (persisted) {
-            createRpc(request, RpcStatus.QUEUED, createdTime);
+            createRpc(request, RpcStatus.QUEUED, createdTime, requestId);
         }
 
         boolean sent = false;
-        int requestId = rpcRequest.getRequestId();
         if (systemContext.isEdgesEnabled() && edgeId != null) {
             log.debug("[{}][{}] device is related to edge: [{}]. Saving RPC request: [{}][{}] to edge queue", tenantId, deviceId, edgeId.getId(), rpcId, requestId);
             try {
@@ -256,11 +256,11 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         };
     }
 
-    private void createRpc(ToDeviceRpcRequest request, RpcStatus status, long createdTime) {
-        systemContext.getTbRpcService().create(tenantId, buildRpc(request, status, null, createdTime));
+    private void createRpc(ToDeviceRpcRequest request, RpcStatus status, long createdTime, int requestId) {
+        systemContext.getTbRpcService().create(tenantId, buildRpc(request, status, null, createdTime, requestId));
     }
 
-    private Rpc buildRpc(ToDeviceRpcRequest request, RpcStatus status, JsonNode response, long createdTime) {
+    private Rpc buildRpc(ToDeviceRpcRequest request, RpcStatus status, JsonNode response, long createdTime, int requestId) {
         Rpc rpc = new Rpc(new RpcId(request.getId()));
         rpc.setCreatedTime(createdTime);
         rpc.setTenantId(tenantId);
@@ -270,6 +270,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         rpc.setResponse(response);
         rpc.setStatus(status);
         rpc.setAdditionalInfo(getAdditionalInfo(request));
+        rpc.setRequestId(requestId);
         return rpc;
     }
 
@@ -355,7 +356,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
             UUID rpcId = toDeviceRpcRequest.getId();
             log.debug("[{}][{}][{}] RPC request timeout detected!", deviceId, rpcId, requestId);
             if (toDeviceRpcRequest.isPersisted()) {
-                systemContext.getTbRpcService().update(tenantId, buildRpc(toDeviceRpcRequest, RpcStatus.EXPIRED, null, requestMd.getCreatedTime()));
+                systemContext.getTbRpcService().update(tenantId, buildRpc(toDeviceRpcRequest, RpcStatus.EXPIRED, null, requestMd.getCreatedTime(), requestId));
             }
             systemContext.getTbCoreDeviceRpcService().processRpcResponseFromDeviceActor(new FromDeviceRpcResponse(rpcId,
                     null, requestMd.isSent() ? RpcError.TIMEOUT : RpcError.NO_ACTIVE_CONNECTION));
@@ -676,7 +677,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
                     } catch (IllegalArgumentException e) {
                         response = JacksonUtil.newObjectNode().put("error", payload);
                     }
-                    systemContext.getTbRpcService().update(tenantId, buildRpc(toDeviceRequestMsg, status, response, requestMd.getCreatedTime()));
+                    systemContext.getTbRpcService().update(tenantId, buildRpc(toDeviceRequestMsg, status, response, requestMd.getCreatedTime(), requestId));
                 }
             } finally {
                 if (rpcSubmitStrategy.equals(RpcSubmitStrategy.SEQUENTIAL_ON_RESPONSE_FROM_DEVICE)) {
@@ -740,7 +741,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
             }
 
             if (persisted) {
-                systemContext.getTbRpcService().update(tenantId, buildRpc(toDeviceRpcRequest, status, response, md.getCreatedTime()));
+                systemContext.getTbRpcService().update(tenantId, buildRpc(toDeviceRpcRequest, status, response, md.getCreatedTime(), requestId));
             }
             if (rpcSubmitStrategy.equals(RpcSubmitStrategy.SEQUENTIAL_ON_RESPONSE_FROM_DEVICE)
                     && status.equals(RpcStatus.DELIVERED) && !oneWayRpc) {
@@ -833,7 +834,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
             var toDeviceRpcRequest = md.getMsg().getMsg();
             if (toDeviceRpcRequest.isPersisted()) {
                 var responseAwaitTimeout = JacksonUtil.newObjectNode().put("error", "There was a timeout awaiting for RPC response from device.");
-                systemContext.getTbRpcService().update(tenantId, buildRpc(toDeviceRpcRequest, RpcStatus.FAILED, responseAwaitTimeout, md.getCreatedTime()));
+                systemContext.getTbRpcService().update(tenantId, buildRpc(toDeviceRpcRequest, RpcStatus.FAILED, responseAwaitTimeout, md.getCreatedTime(), requestId));
             }
         }, systemContext.getRpcResponseTimeout(), TimeUnit.MILLISECONDS);
     }

--- a/application/src/main/java/org/thingsboard/server/service/install/lts/LtsMigration.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/lts/LtsMigration.java
@@ -20,11 +20,46 @@ package org.thingsboard.server.service.install.lts;
  * The runner runs the version's data/upgrade/lts/&lt;version&gt;/schema_update.sql by convention
  * (if present), then calls {@link #apply()} for any programmatic work beyond SQL.
  * Most migrations are SQL-only and only override {@link #getVersion()}.
+ * <p>
+ * Ordering caveat for a multi-version run (see {@link LtsMigrationService#applyMigrations}): on the no-downtime path
+ * every migration's schema_update.sql + {@link #apply()} runs, in version order, BEFORE any migration's
+ * {@link #applyAfterCommit()}. So migration N+1's schema/apply executes ahead of migration N's backfill. A migration
+ * must therefore not depend, in its schema_update.sql or {@link #apply()}, on the completed result of an earlier
+ * migration's {@link #applyAfterCommit()} within the same run.
+ * <p>
+ * The converse constraint also holds: because all schema transactions commit before any {@link #applyAfterCommit()}
+ * runs, migration N's backfill executes against a schema that already includes every later selected migration's DDL.
+ * {@link #applyAfterCommit()} must therefore tolerate the schema changes of every later migration in the same run --
+ * equivalently, later DDL must not drop, rename, or retype anything an earlier migration's backfill reads or writes.
  */
 public interface LtsMigration {
 
     String getVersion();
 
+    /**
+     * Programmatic data migration that runs in the SAME transaction as the version's schema_update.sql
+     * (see {@link LtsMigrationService#applyMigrations}). Use for work that must be atomic with the schema
+     * change. Do NOT put heavy table rewrites here: on the no-downtime path the schema_update.sql DDL holds
+     * its locks until this transaction commits, so a long apply() keeps those locks held while the node serves.
+     * <p>
+     * Must be idempotent: the version is not recorded until {@link #applyAfterCommit()} also succeeds, so a crash
+     * after this transaction commits but before the version is recorded re-runs this method on the next startup.
+     */
     default void apply() {
+    }
+
+    /**
+     * Programmatic data migration that runs AFTER the version's schema transaction has committed, outside any
+     * transaction (see {@link LtsMigrationService#applyMigrations} and {@link LtsMigrationService#runDataMigrations}).
+     * Use for heavy or long-running data backfills that must not extend the lifetime of the schema-change locks:
+     * the implementation is responsible for chunking the work into its own small, self-committing transactions so
+     * it only ever holds row-level locks and never blocks concurrent readers/writers.
+     * <p>
+     * Must be idempotent and resumable: {@link LtsMigrationService#applyMigrations} records the version only after
+     * this method returns, so if the node crashes partway through, the migration is selected again on the next
+     * startup and this method runs again from the start -- it must skip already-migrated rows rather than redo or
+     * double-count them.
+     */
+    default void applyAfterCommit() {
     }
 }

--- a/application/src/main/java/org/thingsboard/server/service/install/lts/LtsMigrationService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/lts/LtsMigrationService.java
@@ -35,6 +35,26 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Applies {@link LtsMigration} beans (in version order) for an LTS upgrade. Each migration has up to four idempotent
+ * parts: (1) its {@code schema_update.sql} DDL, run via {@link #executeSchemaSql} (absent file = no-op); (2)
+ * {@link LtsMigration#apply()}, schema-coupled changes that must be atomic with the DDL; (3)
+ * {@link LtsMigration#applyAfterCommit()}, the heavy backfill, run outside the DDL transaction and self-committing in
+ * chunks; and (4) recording the version, only once (2) and (3) have succeeded.
+ * <p>
+ * Two upgrade strategies compose those parts differently:
+ * <ul>
+ *   <li><b>No-downtime</b> ({@link #applyMigrations}) -- a running node upgrades itself (see SystemPatchApplier). DDL +
+ *   apply() run atomically, then a caller-supplied replay of stored views/functions, then each backfill + version
+ *   record. A crash before a version is recorded re-runs that migration on the next startup, which is why every part
+ *   must be idempotent and resumable.</li>
+ *   <li><b>Offline major upgrade</b> -- runs in the install/upgrade process (node not serving), split across that
+ *   process's schema and data phases: {@link #runSchemaMigrations} (DDL only) runs with the rest of the schema
+ *   upgrade, then {@link #runDataMigrations} (apply() + backfill) runs later, after the install flow has created the
+ *   new tables, views/functions and indexes the data migrations may depend on. Neither records the LTS version; the
+ *   offline upgrade flow tracks the package version itself.</li>
+ * </ul>
+ */
 @Slf4j
 @Component
 @TbCoreComponent
@@ -62,52 +82,65 @@ public class LtsMigrationService {
         this.transactionTemplate = new TransactionTemplate(transactionManager);
         this.migrations = validateAndSort(migrations);
         log.info("Discovered {} LTS migration(s): {}", this.migrations.size(),
-                this.migrations.stream().map(vm -> vm.migration().getVersion()).toList());
+                this.migrations.stream().map(versionedMigration -> versionedMigration.migration().getVersion()).toList());
     }
 
     private static List<VersionedMigration> validateAndSort(List<LtsMigration> migrations) {
         Set<String> seen = new HashSet<>();
         List<VersionedMigration> versioned = new ArrayList<>();
-        for (LtsMigration m : migrations) {
-            LtsVersion version = LtsVersion.parse(m.getVersion()); // fail loud on unparseable version
-            if (!seen.add(m.getVersion())) {
-                throw new IllegalStateException("Duplicate LTS migration version: " + m.getVersion());
+        for (LtsMigration migration : migrations) {
+            LtsVersion version = LtsVersion.parse(migration.getVersion()); // fail loud on unparseable version
+            if (!seen.add(migration.getVersion())) {
+                throw new IllegalStateException("Duplicate LTS migration version: " + migration.getVersion());
             }
-            versioned.add(new VersionedMigration(version, m));
+            versioned.add(new VersionedMigration(version, migration));
         }
         return versioned.stream()
                 .sorted(Comparator.comparing(VersionedMigration::version))
                 .toList();
     }
 
-    /** No-downtime path: per migration in (from, to] run SQL, then apply(), then record the version. */
-    public void applyMigrations(String fromVersion, String toVersion) {
-        for (VersionedMigration vm : select(fromVersion, toVersion)) {
-            LtsMigration migration = vm.migration();
-            String version = migration.getVersion();
+    /**
+     * No-downtime path (see class doc). Phase 1 runs each selected migration's DDL + apply() atomically; then
+     * {@code afterSchemaPhase} replays stored views/functions against the now-complete schema (a migration may have
+     * added a column they reference); then phase 2 runs each backfill and records its version.
+     */
+    public void applyMigrations(String fromVersion, String toVersion, Runnable afterSchemaPhase) {
+        List<VersionedMigration> selected = select(fromVersion, toVersion);
+        for (VersionedMigration versionedMigration : selected) {
+            LtsMigration migration = versionedMigration.migration();
             transactionTemplate.executeWithoutResult(status -> {
-                runSchemaUpdate(version);
+                executeSchemaSql(migration.getVersion());
                 migration.apply();
-                schemaSettingsService.updateSchemaVersion(version);
             });
-            log.info("Applied LTS migration {}", version);
+            log.info("Applied LTS schema update {}", migration.getVersion());
+        }
+        afterSchemaPhase.run();
+        for (VersionedMigration versionedMigration : selected) {
+            LtsMigration migration = versionedMigration.migration();
+            // Backfill outside the schema transaction, version recorded only after it returns (crash-resumable -- see class doc).
+            migration.applyAfterCommit();
+            schemaSettingsService.updateSchemaVersion(migration.getVersion());
+            log.info("Applied LTS migration {}", migration.getVersion());
         }
     }
 
-    /** Offline major-upgrade schema phase: per migration in (from, to] run SQL only. No version record. */
+    /** Offline major upgrade, schema phase: each migration's DDL only, run with the rest of the schema upgrade; apply() is deferred to {@link #runDataMigrations}. */
     public void runSchemaMigrations(String fromVersion, String toVersion) {
-        for (VersionedMigration vm : select(fromVersion, toVersion)) {
-            String version = vm.migration().getVersion();
-            transactionTemplate.executeWithoutResult(status -> runSchemaUpdate(version));
+        for (VersionedMigration versionedMigration : select(fromVersion, toVersion)) {
+            String version = versionedMigration.migration().getVersion();
+            transactionTemplate.executeWithoutResult(status -> executeSchemaSql(version));
             log.info("Applied LTS schema migration {}", version);
         }
     }
 
-    /** Offline major-upgrade data phase: per migration in (from, to] run apply() only. No SQL, no version record. */
+    /** Offline major upgrade, data phase: each migration's apply() + backfill, run after the install flow has set up the new tables/views/indexes. Records no version. */
     public void runDataMigrations(String fromVersion, String toVersion) {
-        for (VersionedMigration vm : select(fromVersion, toVersion)) {
-            vm.migration().apply();
-            log.info("Applied LTS data migration {}", vm.migration().getVersion());
+        for (VersionedMigration versionedMigration : select(fromVersion, toVersion)) {
+            LtsMigration migration = versionedMigration.migration();
+            migration.apply();
+            migration.applyAfterCommit();
+            log.info("Applied LTS data migration {}", migration.getVersion());
         }
     }
 
@@ -115,7 +148,7 @@ public class LtsMigrationService {
         LtsVersion from = LtsVersion.parse(fromVersion);
         LtsVersion to = LtsVersion.parse(toVersion);
         return migrations.stream()
-                .filter(vm -> isInRangeForTargetFamily(vm.version(), from, to))
+                .filter(versionedMigration -> isInRangeForTargetFamily(versionedMigration.version(), from, to))
                 .toList();
     }
 
@@ -129,7 +162,7 @@ public class LtsMigrationService {
         return version.sameFamily(to) && version.isInRange(from, to);
     }
 
-    private void runSchemaUpdate(String version) {
+    private void executeSchemaSql(String version) {
         Path sqlFile = Paths.get(installScripts.getDataDir(), "upgrade", "lts", version, SCHEMA_UPDATE_SQL);
         if (!Files.exists(sqlFile)) {
             log.trace("No LTS schema update file for version {} at {}", version, sqlFile);

--- a/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
@@ -18,6 +18,17 @@ package org.thingsboard.server.service.install.lts;
 import org.springframework.stereotype.Component;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 
+/**
+ * Registration-only migration with no {@link #apply()} (no data migration), kept intentionally.
+ * <p>
+ * {@link LtsMigrationService} selects migrations from the injected {@link LtsMigration} beans, not from the
+ * on-disk {@code data/upgrade/lts/<version>/} directories. So this bean is what makes the runner discover
+ * version {@code 4.3.1.4} and execute its {@code data/upgrade/lts/4.3.1.4/schema_update.sql} (which adds the
+ * nullable {@code rpc.request_id} column). A directory holding a {@code schema_update.sql} but lacking a
+ * matching bean would be silently skipped.
+ * <p>
+ * The dir/bean consistency (both ways) is guarded by a test in {@code LtsMigrationIntegrationTest}.
+ */
 @Component
 @TbCoreComponent
 public class V4_3_1_4Migration implements LtsMigration {

--- a/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.actors.device.DeviceActorMessageProcessor;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 
 import java.util.UUID;
@@ -52,10 +53,8 @@ public class V4_3_1_4Migration implements LtsMigration {
 
     // Same wording as the device actor's LEGACY_UNTRACKED_RESPONSE (DeviceActorMessageProcessor), so a row closed
     // by this one-time backfill reads identically to one closed live by the actor on reload.
-    static final String LEGACY_CLOSE_RESPONSE = JacksonUtil.newObjectNode().put("error",
-            "This RPC was no longer tracked by the platform after a restart and could not reach a terminal state " +
-                    "on its own. It was left stuck in a non-terminal state (SENT or DELIVERED) and has now been " +
-                    "closed automatically.").toString();
+    static final String LEGACY_CLOSE_RESPONSE = JacksonUtil.newObjectNode()
+            .put("error", DeviceActorMessageProcessor.LEGACY_UNTRACKED_MESSAGE).toString();
 
     // Keyset-paginated batch: window of ids > cursor, close the matching legacy rows in that window, report how
     // many closed and the window's max id (the next cursor). Self-contained CTE so a single round trip both

--- a/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
@@ -15,25 +15,124 @@
  */
 package org.thingsboard.server.service.install.lts;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 
+import java.util.UUID;
+
 /**
- * Registration-only migration with no {@link #apply()} (no data migration), kept intentionally.
+ * Registration-only migration with no {@link #apply()} (no data migration), plus an {@link #applyAfterCommit()}
+ * backfill that closes the pre-existing legacy stuck-RPC backlog.
  * <p>
  * {@link LtsMigrationService} selects migrations from the injected {@link LtsMigration} beans, not from the
  * on-disk {@code data/upgrade/lts/<version>/} directories. So this bean is what makes the runner discover
  * version {@code 4.3.1.4} and execute its {@code data/upgrade/lts/4.3.1.4/schema_update.sql} (which adds the
- * nullable {@code rpc.request_id} column). A directory holding a {@code schema_update.sql} but lacking a
- * matching bean would be silently skipped.
+ * nullable {@code rpc.request_id} and {@code rpc.oneway} columns). A directory holding a {@code schema_update.sql}
+ * but lacking a matching bean would be silently skipped.
  * <p>
  * The dir/bean consistency (both ways) is guarded by a test in {@code LtsMigrationIntegrationTest}.
+ * <p>
+ * {@link #applyAfterCommit()} closes rows left stuck by earlier server versions that predate {@code request_id}
+ * tracking: any {@code rpc} row with {@code request_id IS NULL} that is past its expiration and still sitting in
+ * {@code SENT}, or in {@code DELIVERED} for a two-way call (one-way {@code DELIVERED} is already terminal
+ * success), is force-closed to {@code EXPIRED} with a canned response. It walks the {@code rpc} table by primary
+ * key in keyset-paginated, self-committing batches so it never holds a long transaction or blocks concurrent
+ * readers/writers; see the class-level backfill contract on {@link LtsMigration#applyAfterCommit()}.
  */
+@Slf4j
 @Component
 @TbCoreComponent
 public class V4_3_1_4Migration implements LtsMigration {
+
+    // Same wording as the device actor's LEGACY_UNTRACKED_RESPONSE (DeviceActorMessageProcessor), so a row closed
+    // by this one-time backfill reads identically to one closed live by the actor on reload.
+    static final String LEGACY_CLOSE_RESPONSE = JacksonUtil.newObjectNode().put("error",
+            "This RPC was no longer tracked by the platform after a restart and could not reach a terminal state " +
+                    "on its own. It was left stuck in a non-terminal state (SENT or DELIVERED) and has now been " +
+                    "closed automatically.").toString();
+
+    // Keyset-paginated batch: window of ids > cursor, close the matching legacy rows in that window, report how
+    // many closed and the window's max id (the next cursor). Self-contained CTE so a single round trip both
+    // selects the window and performs the conditional update.
+    static final String CLEANUP_BATCH_SQL = """
+            WITH w AS (
+              SELECT id FROM rpc WHERE id > ? ORDER BY id LIMIT ?
+            ), u AS (
+              UPDATE rpc SET status = 'EXPIRED', response = ?
+              FROM w WHERE rpc.id = w.id
+                AND rpc.request_id IS NULL
+                AND rpc.expiration_time < ?
+                AND (rpc.status = 'SENT' OR (rpc.status = 'DELIVERED' AND (rpc.request::jsonb ->> 'oneway') = 'false'))
+              RETURNING 1
+            )
+            SELECT (SELECT count(*) FROM u) AS updated_count,
+                   (SELECT id FROM w ORDER BY id DESC LIMIT 1) AS last_id
+            """;
+
+    private static final UUID MIN_UUID = new UUID(0L, 0L);
+
+    private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate transactionTemplate;
+
+    @Value("${install.rpc_legacy_cleanup_batch_size:50000}")
+    private int batchSize;
+
+    public V4_3_1_4Migration(JdbcTemplate jdbcTemplate, PlatformTransactionManager transactionManager) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
+    }
+
     @Override
     public String getVersion() {
         return "4.3.1.4";
+    }
+
+    @Override
+    public void applyAfterCommit() {
+        long now = System.currentTimeMillis();
+        UUID cursor = MIN_UUID;
+        long totalClosed = 0;
+        long totalBatches = 0;
+        while (true) {
+            BatchResult result = runBatch(cursor, now);
+            if (result.lastId() == null) {
+                break;
+            }
+            if (comparePgUuid(result.lastId(), cursor) <= 0) {
+                // Defensive: the window is ORDER BY id ASC over id > cursor, so its max must strictly exceed
+                // cursor. A non-increasing cursor would spin forever, so fail loudly instead.
+                throw new IllegalStateException("Legacy RPC cleanup cursor failed to advance: cursor=" + cursor
+                        + " lastId=" + result.lastId());
+            }
+            cursor = result.lastId();
+            totalClosed += result.updatedCount();
+            totalBatches++;
+        }
+        log.info("Legacy RPC backlog cleanup closed {} row(s) in {} batch(es)", totalClosed, totalBatches);
+    }
+
+    private BatchResult runBatch(UUID cursor, long now) {
+        return transactionTemplate.execute(status -> jdbcTemplate.queryForObject(CLEANUP_BATCH_SQL,
+                (rs, rowNum) -> new BatchResult(rs.getLong("updated_count"), (UUID) rs.getObject("last_id")),
+                cursor, batchSize, LEGACY_CLOSE_RESPONSE, now));
+    }
+
+    // PostgreSQL orders uuid values byte-for-byte, i.e. as unsigned 128-bit integers -- NOT as Java's
+    // UUID.compareTo, which treats the MSB/LSB longs as signed. Compare the same way the ORDER BY does.
+    private static int comparePgUuid(UUID a, UUID b) {
+        int cmp = Long.compareUnsigned(a.getMostSignificantBits(), b.getMostSignificantBits());
+        if (cmp != 0) {
+            return cmp;
+        }
+        return Long.compareUnsigned(a.getLeastSignificantBits(), b.getLeastSignificantBits());
+    }
+
+    private record BatchResult(long updatedCount, UUID lastId) {
     }
 }

--- a/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
@@ -51,14 +51,17 @@ import java.util.UUID;
 @TbCoreComponent
 public class V4_3_1_4Migration implements LtsMigration {
 
-    // Same wording as the device actor's LEGACY_UNTRACKED_RESPONSE (DeviceActorMessageProcessor), so a row closed
-    // by this one-time backfill reads identically to one closed live by the actor on reload.
+    // Same wording as DeviceActorMessageProcessor.LEGACY_UNTRACKED_MESSAGE, so a row closed by this one-time
+    // backfill reads identically to one closed live by the actor on reload.
     static final String LEGACY_CLOSE_RESPONSE = JacksonUtil.newObjectNode()
             .put("error", DeviceActorMessageProcessor.LEGACY_UNTRACKED_MESSAGE).toString();
 
     // Keyset-paginated batch: window of ids > cursor, close the matching legacy rows in that window, report how
     // many closed and the window's max id (the next cursor). Self-contained CTE so a single round trip both
     // selects the window and performs the conditional update.
+    // The window scan (`id > ?`) walks the table in id order regardless of how many rows match — that's fine
+    // here: during this one-time upgrade every legacy row has request_id IS NULL, so an index on that predicate
+    // would not be selective and wouldn't speed anything up.
     static final String CLEANUP_BATCH_SQL = """
             WITH w AS (
               SELECT id FROM rpc WHERE id > ? ORDER BY id LIMIT ?

--- a/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
@@ -41,7 +41,7 @@ import java.util.UUID;
  * <p>
  * {@link #applyAfterCommit()} closes rows left stuck by earlier server versions that predate {@code request_id}
  * tracking: any {@code rpc} row with {@code request_id IS NULL} that is past its expiration and still sitting in
- * {@code SENT}, or in {@code DELIVERED} for a two-way call (one-way {@code DELIVERED} is already terminal
+ * {@code SENT} or {@code TIMEOUT}, or in {@code DELIVERED} for a two-way call (one-way {@code DELIVERED} is already terminal
  * success), is force-closed to {@code EXPIRED} with a canned response. It walks the {@code rpc} table by primary
  * key in keyset-paginated, self-committing batches so it never holds a long transaction or blocks concurrent
  * readers/writers; see the class-level backfill contract on {@link LtsMigration#applyAfterCommit()}.
@@ -70,7 +70,7 @@ public class V4_3_1_4Migration implements LtsMigration {
               FROM w WHERE rpc.id = w.id
                 AND rpc.request_id IS NULL
                 AND rpc.expiration_time < ?
-                AND (rpc.status = 'SENT' OR (rpc.status = 'DELIVERED' AND (rpc.request::jsonb ->> 'oneway') = 'false'))
+                AND (rpc.status IN ('SENT','TIMEOUT') OR (rpc.status = 'DELIVERED' AND (rpc.request::jsonb ->> 'oneway') = 'false'))
               RETURNING 1
             )
             SELECT (SELECT count(*) FROM u) AS updated_count,

--- a/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/lts/V4_3_1_4Migration.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.install.lts;
+
+import org.springframework.stereotype.Component;
+import org.thingsboard.server.queue.util.TbCoreComponent;
+
+@Component
+@TbCoreComponent
+public class V4_3_1_4Migration implements LtsMigration {
+    @Override
+    public String getVersion() {
+        return "4.3.1.4";
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
+++ b/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
@@ -37,6 +37,7 @@ import org.thingsboard.server.common.msg.TbMsgMetaData;
 import org.thingsboard.server.dao.rpc.RpcService;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 
+import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -121,6 +122,10 @@ public class TbRpcService {
 
     public PageData<Rpc> findAllByDeviceIdAndStatus(TenantId tenantId, DeviceId deviceId, RpcStatus rpcStatus, PageLink pageLink) {
         return rpcService.findAllByDeviceIdAndStatus(tenantId, deviceId, rpcStatus, pageLink);
+    }
+
+    public PageData<Rpc> findAllByDeviceIdAndStatusIn(TenantId tenantId, DeviceId deviceId, Collection<RpcStatus> statuses, PageLink pageLink) {
+        return rpcService.findAllByDeviceIdAndStatusIn(tenantId, deviceId, statuses, pageLink);
     }
 
 }

--- a/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
+++ b/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
@@ -31,7 +31,6 @@ import org.thingsboard.server.common.data.msg.TbMsgType;
 import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.PageLink;
 import org.thingsboard.server.common.data.rpc.Rpc;
-import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.common.msg.TbMsgMetaData;
 import org.thingsboard.server.dao.rpc.RpcService;
@@ -117,10 +116,6 @@ public class TbRpcService {
                 .data(JacksonUtil.toString(rpc))
                 .build();
         tbClusterService.pushMsgToRuleEngine(tenantId, rpc.getDeviceId(), msg, null);
-    }
-
-    public PageData<Rpc> findAllByDeviceIdAndStatus(TenantId tenantId, DeviceId deviceId, RpcStatus rpcStatus, PageLink pageLink) {
-        return rpcService.findAllByDeviceIdAndStatus(tenantId, deviceId, rpcStatus, pageLink);
     }
 
     public PageData<Rpc> findInFlightForReload(TenantId tenantId, DeviceId deviceId, PageLink pageLink) {

--- a/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
+++ b/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
@@ -37,7 +37,6 @@ import org.thingsboard.server.common.msg.TbMsgMetaData;
 import org.thingsboard.server.dao.rpc.RpcService;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 
-import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -124,8 +123,8 @@ public class TbRpcService {
         return rpcService.findAllByDeviceIdAndStatus(tenantId, deviceId, rpcStatus, pageLink);
     }
 
-    public PageData<Rpc> findAllByDeviceIdAndStatusIn(TenantId tenantId, DeviceId deviceId, Collection<RpcStatus> statuses, PageLink pageLink) {
-        return rpcService.findAllByDeviceIdAndStatusIn(tenantId, deviceId, statuses, pageLink);
+    public PageData<Rpc> findInFlightForReload(TenantId tenantId, DeviceId deviceId, PageLink pageLink) {
+        return rpcService.findInFlightForReload(tenantId, deviceId, pageLink);
     }
 
 }

--- a/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
+++ b/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
@@ -86,7 +86,7 @@ public class TbRpcService {
                     if (Boolean.TRUE.equals(persisted)) {
                         notifyRuleEngine(tenantId, rpc);
                     } else {
-                        log.debug("[{}][{}][{}] Skipping rule engine notification for status [{}] - RPC row no longer exists",
+                        log.debug("[{}][{}][{}] Skipping rule engine notification for status [{}] - RPC row is not updatable (already terminal or removed)",
                                 tenantId, rpc.getDeviceId(), rpc.getId(), rpc.getStatus());
                     }
                 },

--- a/application/src/main/java/org/thingsboard/server/service/system/SystemPatchApplier.java
+++ b/application/src/main/java/org/thingsboard/server/service/system/SystemPatchApplier.java
@@ -106,10 +106,10 @@ public class SystemPatchApplier {
         try {
             String dbVersion = schemaSettingsService.getDbSchemaVersion();
             String packageVersion = schemaSettingsService.getPackageSchemaVersion();
-            ltsMigrationService.applyMigrations(dbVersion, packageVersion);
-
-            updateSqlViews();
-            log.info("Updated sql database views");
+            ltsMigrationService.applyMigrations(dbVersion, packageVersion, () -> {
+                updateSqlViews();
+                log.info("Updated sql database views");
+            });
 
             WidgetTypeStats widgetStats = updateWidgetTypes();
             log.info("System widget types: {} created, {} updated", widgetStats.created(), widgetStats.updated());

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -34,7 +34,9 @@ import org.thingsboard.server.common.msg.rpc.ToDeviceRpcRequest;
 import org.thingsboard.server.common.msg.rpc.ToDeviceRpcRequestActorMsg;
 import org.thingsboard.server.dao.device.DeviceService;
 import org.thingsboard.server.gen.transport.TransportProtos.SessionInfoProto;
+import org.thingsboard.server.gen.transport.TransportProtos.SessionType;
 import org.thingsboard.server.gen.transport.TransportProtos.ToDeviceRpcResponseMsg;
+import org.thingsboard.server.gen.transport.TransportProtos.ToTransportMsg;
 import org.thingsboard.server.service.rpc.TbCoreDeviceRpcService;
 import org.thingsboard.server.service.rpc.TbRpcService;
 import org.thingsboard.server.service.transport.TbCoreToTransportService;
@@ -50,6 +52,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -222,6 +225,53 @@ public class DeviceActorMessageProcessorTest {
         ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
         verify(rpcService).create(eq(tenantId), captor.capture());
         org.assertj.core.api.Assertions.assertThat(captor.getValue().getRequestId()).isEqualTo(6);
+    }
+
+    @Test
+    public void resubscribeReSendsUndeliveredButNotDelivered() {
+        TbRpcService rpcService = mock(TbRpcService.class);
+        willReturn(rpcService).given(systemContext).getTbRpcService();
+        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
+        willReturn("svc").given(systemContext).getServiceId();
+        TbCoreToTransportService toTransport = mock(TbCoreToTransportService.class);
+        willReturn(toTransport).given(systemContext).getTbCoreToTransportService();
+
+        Rpc sent = inFlightRow(RpcStatus.SENT, 6, 1000L);        // undelivered
+        Rpc delivered = inFlightRow(RpcStatus.DELIVERED, 5, 2000L);
+        stubReload(rpcService, RpcStatus.QUEUED);
+        willReturn(new PageData<>(List.of(sent), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.SENT), any());
+        willReturn(new PageData<>(List.of(delivered), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.DELIVERED), any());
+        processor.init(mock(TbActorCtx.class));
+
+        // seed an ASYNC session so sendPendingRequests takes the forEach branch, then push directly:
+        UUID sessionId = UUID.randomUUID();
+        SessionInfo sessionInfo = new SessionInfo(SessionType.ASYNC, "svc");
+        processor.sessions.put(sessionId, new SessionInfoMetaData(sessionInfo));
+        processor.rpcSubscriptions.put(sessionId, sessionInfo);
+        processor.sendPendingRequests(sessionId, "svc");
+
+        // sendToTransport wraps the request in a ToTransportMsg and calls the 2-arg process(nodeId, msg):
+        ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
+        verify(toTransport, atLeastOnce()).process(any(), captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getAllValues())
+                .extracting(m -> m.getToDeviceRequest().getRequestId())
+                .contains(6).doesNotContain(5); // undelivered re-sent, delivered not
+    }
+
+    private Rpc inFlightRow(RpcStatus status, int requestId, long createdTime) {
+        UUID rpcUuid = UUID.randomUUID();
+        long exp = System.currentTimeMillis() + 60_000;
+        ToDeviceRpcRequest req = new ToDeviceRpcRequest(rpcUuid, tenantId, deviceId, false, exp,
+                new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
+        Rpc rpc = new Rpc(new RpcId(rpcUuid));
+        rpc.setCreatedTime(createdTime);
+        rpc.setExpirationTime(exp);
+        rpc.setStatus(status);
+        rpc.setRequestId(requestId);
+        rpc.setRequest(JacksonUtil.valueToTree(req));
+        return rpc;
     }
 
     private void stubReload(TbRpcService s, RpcStatus st) {

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -258,6 +258,25 @@ public class DeviceActorMessageProcessorTest {
         assertThat(publishedRequestIds()).contains(9).doesNotContain(7);
     }
 
+    @Test
+    public void legacyNullSentRowIsClosedNotRePublished() {
+        mockRpcInfra();
+        Rpc row = row(UUID.randomUUID(), RpcStatus.SENT, System.currentTimeMillis(),
+                System.currentTimeMillis() + 60_000, false); // two-way, future expiration
+        row.setRequestId(null); // legacy pre-migration row: no persisted requestId
+        stubInFlight(row);
+
+        processor.init(mock(TbActorCtx.class));
+        pushViaAsyncSession();
+
+        // untrackable legacy row must be closed (not re-armed/re-published):
+        ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
+        verify(rpcService).update(eq(tenantId), captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(RpcStatus.FAILED);
+        assertThat(captor.getValue().getResponse()).isNotNull();
+        Mockito.verify(toTransport, Mockito.never()).process(any(), any());
+    }
+
     private void mockRpcInfra() {
         rpcService = mock(TbRpcService.class);
         willReturn(rpcService).given(systemContext).getTbRpcService();

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -267,11 +267,12 @@ public class DeviceActorMessageProcessorTest {
         willReturn(toTransport).given(systemContext).getTbCoreToTransportService();
     }
 
-    // The reload issues a single findAllByDeviceIdAndStatusIn query; the actor sorts the rows itself, so the
-    // stub just returns them all in one page regardless of order.
+    // The reload issues a single findInFlightForReload query (DB-side filters out one-way DELIVERED and
+    // terminal statuses - see JpaRpcDaoTest); the actor sorts the rows itself, so the stub just returns
+    // them all in one page regardless of order.
     private void stubInFlight(Rpc... rows) {
         willReturn(new PageData<>(List.of(rows), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatusIn(eq(tenantId), eq(deviceId), any(), any());
+                .findInFlightForReload(eq(tenantId), eq(deviceId), any());
     }
 
     private void pushViaAsyncSession() {

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -44,6 +44,7 @@ import org.thingsboard.server.service.transport.TbCoreToTransportService;
 import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -120,7 +121,7 @@ public class DeviceActorMessageProcessorTest {
 
         ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
         verify(rpcService).create(eq(tenantId), captor.capture());
-        org.assertj.core.api.Assertions.assertThat(captor.getValue().getRequestId()).isEqualTo(0); // first rpcSeq
+        assertThat(captor.getValue().getRequestId()).isEqualTo(0); // first rpcSeq
     }
 
     @Test
@@ -159,7 +160,7 @@ public class DeviceActorMessageProcessorTest {
         // matched → row updated to SUCCESSFUL (not "stale"):
         ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
         verify(rpcService).update(eq(tenantId), captor.capture());
-        org.assertj.core.api.Assertions.assertThat(captor.getValue().getStatus()).isEqualTo(RpcStatus.SUCCESSFUL);
+        assertThat(captor.getValue().getStatus()).isEqualTo(RpcStatus.SUCCESSFUL);
     }
 
     @Test
@@ -224,7 +225,7 @@ public class DeviceActorMessageProcessorTest {
 
         ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
         verify(rpcService).create(eq(tenantId), captor.capture());
-        org.assertj.core.api.Assertions.assertThat(captor.getValue().getRequestId()).isEqualTo(6);
+        assertThat(captor.getValue().getRequestId()).isEqualTo(6);
     }
 
     @Test
@@ -255,7 +256,7 @@ public class DeviceActorMessageProcessorTest {
         // sendToTransport wraps the request in a ToTransportMsg and calls the 2-arg process(nodeId, msg):
         ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
         verify(toTransport, atLeastOnce()).process(any(), captor.capture());
-        org.assertj.core.api.Assertions.assertThat(captor.getAllValues())
+        assertThat(captor.getAllValues())
                 .extracting(m -> m.getToDeviceRequest().getRequestId())
                 .contains(6).doesNotContain(5); // undelivered re-sent, delivered not
     }
@@ -286,7 +287,7 @@ public class DeviceActorMessageProcessorTest {
         // one-way SENT is no longer skipped on reload — it must be re-published to the device:
         ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
         verify(toTransport, atLeastOnce()).process(any(), captor.capture());
-        org.assertj.core.api.Assertions.assertThat(captor.getAllValues())
+        assertThat(captor.getAllValues())
                 .extracting(m -> m.getToDeviceRequest().getRequestId())
                 .contains(6);
     }
@@ -328,7 +329,7 @@ public class DeviceActorMessageProcessorTest {
         // fresh-id fallback (rpcSeq, starting at 0) was assigned and the row was registered/re-published:
         ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
         verify(toTransport, atLeastOnce()).process(any(), captor.capture());
-        org.assertj.core.api.Assertions.assertThat(captor.getAllValues())
+        assertThat(captor.getAllValues())
                 .extracting(m -> m.getToDeviceRequest().getRequestId())
                 .contains(0);
     }
@@ -366,7 +367,7 @@ public class DeviceActorMessageProcessorTest {
         // the bad row is silently skipped; the following good row still restores and re-publishes:
         ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
         verify(toTransport, atLeastOnce()).process(any(), captor.capture());
-        org.assertj.core.api.Assertions.assertThat(captor.getAllValues())
+        assertThat(captor.getAllValues())
                 .extracting(m -> m.getToDeviceRequest().getRequestId())
                 .contains(9)
                 .doesNotContain(7);

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -260,10 +260,87 @@ public class DeviceActorMessageProcessorTest {
                 .contains(6).doesNotContain(5); // undelivered re-sent, delivered not
     }
 
-    private Rpc inFlightRow(RpcStatus status, int requestId, long createdTime) {
+    @Test
+    public void oneWaySentRowIsRePublishedOnReload() {
+        TbRpcService rpcService = mock(TbRpcService.class);
+        willReturn(rpcService).given(systemContext).getTbRpcService();
+        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
+        willReturn("svc").given(systemContext).getServiceId();
+        TbCoreToTransportService toTransport = mock(TbCoreToTransportService.class);
+        willReturn(toTransport).given(systemContext).getTbCoreToTransportService();
+
+        Rpc onewaySent = inFlightRow(RpcStatus.SENT, 6, 1000L, true); // one-way, QoS-1 publish->PUBACK window
+        stubReload(rpcService, RpcStatus.QUEUED);
+        stubReload(rpcService, RpcStatus.DELIVERED);
+        willReturn(new PageData<>(List.of(onewaySent), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.SENT), any());
+        processor.init(mock(TbActorCtx.class));
+
+        // seed an ASYNC session so sendPendingRequests takes the forEach branch, then push directly:
+        UUID sessionId = UUID.randomUUID();
+        SessionInfo sessionInfo = new SessionInfo(SessionType.ASYNC, "svc");
+        processor.sessions.put(sessionId, new SessionInfoMetaData(sessionInfo));
+        processor.rpcSubscriptions.put(sessionId, sessionInfo);
+        processor.sendPendingRequests(sessionId, "svc");
+
+        // one-way SENT is no longer skipped on reload — it must be re-published to the device:
+        ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
+        verify(toTransport, atLeastOnce()).process(any(), captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getAllValues())
+                .extracting(m -> m.getToDeviceRequest().getRequestId())
+                .contains(6);
+    }
+
+    @Test
+    public void legacyNullRequestIdRowReloadsWithoutNpe() {
+        TbRpcService rpcService = mock(TbRpcService.class);
+        willReturn(rpcService).given(systemContext).getTbRpcService();
+        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
+        willReturn("svc").given(systemContext).getServiceId();
+        TbCoreToTransportService toTransport = mock(TbCoreToTransportService.class);
+        willReturn(toTransport).given(systemContext).getTbCoreToTransportService();
+
         UUID rpcUuid = UUID.randomUUID();
         long exp = System.currentTimeMillis() + 60_000;
         ToDeviceRpcRequest req = new ToDeviceRpcRequest(rpcUuid, tenantId, deviceId, false, exp,
+                new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
+        Rpc legacyRow = new Rpc(new RpcId(rpcUuid));
+        legacyRow.setCreatedTime(System.currentTimeMillis());
+        legacyRow.setExpirationTime(exp);
+        legacyRow.setStatus(RpcStatus.QUEUED);
+        legacyRow.setRequestId(null); // legacy pre-migration row: no persisted requestId
+        legacyRow.setRequest(JacksonUtil.valueToTree(req));
+
+        willReturn(new PageData<>(List.of(legacyRow), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.QUEUED), any());
+        stubReload(rpcService, RpcStatus.SENT);
+        stubReload(rpcService, RpcStatus.DELIVERED);
+
+        TbActorCtx ctx = mock(TbActorCtx.class);
+        processor.init(ctx); // must not NPE despite the null persisted requestId
+
+        UUID sessionId = UUID.randomUUID();
+        SessionInfo sessionInfo = new SessionInfo(SessionType.ASYNC, "svc");
+        processor.sessions.put(sessionId, new SessionInfoMetaData(sessionInfo));
+        processor.rpcSubscriptions.put(sessionId, sessionInfo);
+        processor.sendPendingRequests(sessionId, "svc");
+
+        // fresh-id fallback (rpcSeq, starting at 0) was assigned and the row was registered/re-published:
+        ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
+        verify(toTransport, atLeastOnce()).process(any(), captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getAllValues())
+                .extracting(m -> m.getToDeviceRequest().getRequestId())
+                .contains(0);
+    }
+
+    private Rpc inFlightRow(RpcStatus status, int requestId, long createdTime) {
+        return inFlightRow(status, requestId, createdTime, false);
+    }
+
+    private Rpc inFlightRow(RpcStatus status, int requestId, long createdTime, boolean oneway) {
+        UUID rpcUuid = UUID.randomUUID();
+        long exp = System.currentTimeMillis() + 60_000;
+        ToDeviceRpcRequest req = new ToDeviceRpcRequest(rpcUuid, tenantId, deviceId, oneway, exp,
                 new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
         Rpc rpc = new Rpc(new RpcId(rpcUuid));
         rpc.setCreatedTime(createdTime);

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -192,6 +192,43 @@ public class DeviceActorMessageProcessorTest {
         Mockito.verify(rpcService, Mockito.never()).update(any(), any());
     }
 
+    @Test
+    public void seedsCounterPastHighestReloadedId() {
+        TbRpcService rpcService = mock(TbRpcService.class);
+        willReturn(rpcService).given(systemContext).getTbRpcService();
+        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
+        willReturn("svc").given(systemContext).getServiceId();
+
+        Rpc row = new Rpc(new RpcId(UUID.randomUUID()));
+        row.setCreatedTime(System.currentTimeMillis());
+        row.setExpirationTime(System.currentTimeMillis() + 60_000);
+        row.setStatus(RpcStatus.SENT);
+        row.setRequestId(5);
+        row.setRequest(JacksonUtil.valueToTree(new ToDeviceRpcRequest(row.getUuidId(), tenantId, deviceId,
+                false, row.getExpirationTime(), new ToDeviceRpcRequestBody("m", "{}"), true, null, null)));
+        stubReload(rpcService, RpcStatus.QUEUED); // empty
+        stubReload(rpcService, RpcStatus.DELIVERED); // empty
+        willReturn(new PageData<>(List.of(row), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.SENT), any());
+
+        TbActorCtx ctx = mock(TbActorCtx.class);
+        processor.init(ctx);
+
+        // next brand-new persistent RPC must get id 6, not 0:
+        ToDeviceRpcRequest req = new ToDeviceRpcRequest(UUID.randomUUID(), tenantId, deviceId, false,
+                System.currentTimeMillis() + 60_000, new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
+        processor.processRpcRequest(ctx, new ToDeviceRpcRequestActorMsg("svc", req));
+
+        ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
+        verify(rpcService).create(eq(tenantId), captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getRequestId()).isEqualTo(6);
+    }
+
+    private void stubReload(TbRpcService s, RpcStatus st) {
+        willReturn(new PageData<>(List.of(), 1, 0, false)).given(s)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(st), any());
+    }
+
     private SessionInfoProto sessionInfoProto() {
         UUID sid = UUID.randomUUID();
         return SessionInfoProto.newBuilder()

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -333,6 +333,45 @@ public class DeviceActorMessageProcessorTest {
                 .contains(0);
     }
 
+    @Test
+    public void nullRequestRowIsSkippedWithoutAbortingReload() {
+        TbRpcService rpcService = mock(TbRpcService.class);
+        willReturn(rpcService).given(systemContext).getTbRpcService();
+        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
+        willReturn("svc").given(systemContext).getServiceId();
+        TbCoreToTransportService toTransport = mock(TbCoreToTransportService.class);
+        willReturn(toTransport).given(systemContext).getTbCoreToTransportService();
+
+        // corrupt/legacy row whose request JSON deserializes to null — processed FIRST (earlier createdTime):
+        Rpc badRow = new Rpc(new RpcId(UUID.randomUUID()));
+        badRow.setCreatedTime(999L);
+        badRow.setExpirationTime(System.currentTimeMillis() + 60_000);
+        badRow.setStatus(RpcStatus.QUEUED);
+        badRow.setRequestId(7);
+        badRow.setRequest(null); // JacksonUtil.convertValue(null, ...) returns null -> restore must skip, not NPE
+        Rpc goodRow = inFlightRow(RpcStatus.QUEUED, 9, 1000L);
+        willReturn(new PageData<>(List.of(badRow, goodRow), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.QUEUED), any());
+        stubReload(rpcService, RpcStatus.SENT);
+        stubReload(rpcService, RpcStatus.DELIVERED);
+
+        processor.init(mock(TbActorCtx.class)); // must not NPE on the null-request row
+
+        UUID sessionId = UUID.randomUUID();
+        SessionInfo sessionInfo = new SessionInfo(SessionType.ASYNC, "svc");
+        processor.sessions.put(sessionId, new SessionInfoMetaData(sessionInfo));
+        processor.rpcSubscriptions.put(sessionId, sessionInfo);
+        processor.sendPendingRequests(sessionId, "svc");
+
+        // the bad row is silently skipped; the following good row still restores and re-publishes:
+        ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
+        verify(toTransport, atLeastOnce()).process(any(), captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getAllValues())
+                .extracting(m -> m.getToDeviceRequest().getRequestId())
+                .contains(9)
+                .doesNotContain(7);
+    }
+
     private Rpc inFlightRow(RpcStatus status, int requestId, long createdTime) {
         return inFlightRow(status, requestId, createdTime, false);
     }

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -159,6 +159,39 @@ public class DeviceActorMessageProcessorTest {
         org.assertj.core.api.Assertions.assertThat(captor.getValue().getStatus()).isEqualTo(RpcStatus.SUCCESSFUL);
     }
 
+    @Test
+    public void oneWayDeliveredRowNotReExpiredOnReload() {
+        TbRpcService rpcService = mock(TbRpcService.class);
+        willReturn(rpcService).given(systemContext).getTbRpcService();
+        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
+        willReturn("svc").given(systemContext).getServiceId();
+
+        UUID rpcUuid = UUID.randomUUID();
+        long pastExp = System.currentTimeMillis() - 60_000; // already expired
+        ToDeviceRpcRequest req = new ToDeviceRpcRequest(rpcUuid, tenantId, deviceId, true /*oneway*/,
+                pastExp, new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
+        Rpc row = new Rpc(new RpcId(rpcUuid));
+        row.setCreatedTime(System.currentTimeMillis() - 120_000);
+        row.setExpirationTime(pastExp);
+        row.setStatus(RpcStatus.DELIVERED);
+        row.setRequestId(9);
+        row.setRequest(JacksonUtil.valueToTree(req));
+
+        // QUEUED/SENT empty, DELIVERED returns our past-due one-way row:
+        willReturn(new PageData<>(List.of(), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.QUEUED), any());
+        willReturn(new PageData<>(List.of(), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.SENT), any());
+        willReturn(new PageData<>(List.of(row), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.DELIVERED), any());
+
+        TbActorCtx ctx = mock(TbActorCtx.class);
+        processor.init(ctx);
+
+        // terminal one-way DELIVERED row, past expiry: must be left untouched, no EXPIRED overwrite
+        Mockito.verify(rpcService, Mockito.never()).update(any(), any());
+    }
+
     private SessionInfoProto sessionInfoProto() {
         UUID sid = UUID.randomUUID();
         return SessionInfoProto.newBuilder()

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -59,10 +59,10 @@ import static org.mockito.Mockito.verify;
 
 public class DeviceActorMessageProcessorTest {
 
-    public static final int MAX_CONCURRENT_SESSIONS_PER_DEVICE = 10;
+    private static final int MAX_CONCURRENT_SESSIONS_PER_DEVICE = 1;
     ActorSystemContext systemContext;
     DeviceService deviceService;
-    TenantId tenantId = TenantId.SYS_TENANT_ID;
+    TenantId tenantId = TenantId.fromUUID(UUID.fromString("ae651b45-2a92-4bdf-9d56-faede44eafb8"));
     DeviceId deviceId = DeviceId.fromString("78bf9b26-74ef-4af2-9cfb-ad6cf24ad2ec");
 
     DeviceActorMessageProcessor processor;

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -66,6 +66,8 @@ public class DeviceActorMessageProcessorTest {
     DeviceId deviceId = DeviceId.fromString("78bf9b26-74ef-4af2-9cfb-ad6cf24ad2ec");
 
     DeviceActorMessageProcessor processor;
+    TbRpcService rpcService;
+    TbCoreToTransportService toTransport;
 
     @Before
     public void setUp() {
@@ -109,9 +111,7 @@ public class DeviceActorMessageProcessorTest {
 
     @Test
     public void persistsRequestIdOnCreate() {
-        TbRpcService rpcService = mock(TbRpcService.class);
-        willReturn(rpcService).given(systemContext).getTbRpcService();
-        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
+        mockRpcInfra();
 
         TbActorCtx ctx = mock(TbActorCtx.class);
         ToDeviceRpcRequest request = new ToDeviceRpcRequest(UUID.randomUUID(), tenantId, deviceId,
@@ -126,32 +126,11 @@ public class DeviceActorMessageProcessorTest {
 
     @Test
     public void reloadedDeliveredRpcMatchesDeviceResponse() {
-        TbRpcService rpcService = mock(TbRpcService.class);
-        willReturn(rpcService).given(systemContext).getTbRpcService();
-        TbCoreDeviceRpcService coreRpc = mock(TbCoreDeviceRpcService.class);
-        willReturn(coreRpc).given(systemContext).getTbCoreDeviceRpcService();
-        willReturn("svc").given(systemContext).getServiceId();
+        mockRpcInfra();
+        Rpc row = inFlightRow(RpcStatus.DELIVERED, 7, System.currentTimeMillis());
+        stubInFlight(row);
 
-        UUID rpcUuid = UUID.randomUUID();
-        ToDeviceRpcRequest req = new ToDeviceRpcRequest(rpcUuid, tenantId, deviceId, false,
-                System.currentTimeMillis() + 60_000, new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
-        Rpc row = new Rpc(new RpcId(rpcUuid));
-        row.setCreatedTime(System.currentTimeMillis());
-        row.setExpirationTime(System.currentTimeMillis() + 60_000);
-        row.setStatus(RpcStatus.DELIVERED);
-        row.setRequestId(7);
-        row.setRequest(JacksonUtil.valueToTree(req));
-
-        // QUEUED/SENT empty, DELIVERED returns our row:
-        willReturn(new PageData<>(List.of(), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.QUEUED), any());
-        willReturn(new PageData<>(List.of(), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.SENT), any());
-        willReturn(new PageData<>(List.of(row), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.DELIVERED), any());
-
-        TbActorCtx ctx = mock(TbActorCtx.class);
-        processor.init(ctx);
+        processor.init(mock(TbActorCtx.class));
 
         // device replies with the OLD id 7:
         processor.processRpcResponses(sessionInfoProto(), ToDeviceRpcResponseMsg.newBuilder()
@@ -165,63 +144,43 @@ public class DeviceActorMessageProcessorTest {
 
     @Test
     public void oneWayDeliveredRowNotReExpiredOnReload() {
-        TbRpcService rpcService = mock(TbRpcService.class);
-        willReturn(rpcService).given(systemContext).getTbRpcService();
-        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
-        willReturn("svc").given(systemContext).getServiceId();
-
-        UUID rpcUuid = UUID.randomUUID();
+        mockRpcInfra();
         long pastExp = System.currentTimeMillis() - 60_000; // already expired
-        ToDeviceRpcRequest req = new ToDeviceRpcRequest(rpcUuid, tenantId, deviceId, true /*oneway*/,
-                pastExp, new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
-        Rpc row = new Rpc(new RpcId(rpcUuid));
-        row.setCreatedTime(System.currentTimeMillis() - 120_000);
-        row.setExpirationTime(pastExp);
-        row.setStatus(RpcStatus.DELIVERED);
-        row.setRequestId(9);
-        row.setRequest(JacksonUtil.valueToTree(req));
+        Rpc row = expiredRow(RpcStatus.DELIVERED, 9, true /*oneway*/, pastExp);
+        stubInFlight(row);
 
-        // QUEUED/SENT empty, DELIVERED returns our past-due one-way row:
-        willReturn(new PageData<>(List.of(), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.QUEUED), any());
-        willReturn(new PageData<>(List.of(), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.SENT), any());
-        willReturn(new PageData<>(List.of(row), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.DELIVERED), any());
-
-        TbActorCtx ctx = mock(TbActorCtx.class);
-        processor.init(ctx);
+        processor.init(mock(TbActorCtx.class));
 
         // terminal one-way DELIVERED row, past expiry: must be left untouched, no EXPIRED overwrite
         Mockito.verify(rpcService, Mockito.never()).update(any(), any());
     }
 
     @Test
+    public void pastExpiryTwoWaySentRowIsExpiredOnReload() {
+        mockRpcInfra();
+        long pastExp = System.currentTimeMillis() - 60_000; // already expired
+        Rpc row = expiredRow(RpcStatus.SENT, 3, false /*two-way*/, pastExp);
+        stubInFlight(row);
+
+        processor.init(mock(TbActorCtx.class));
+
+        // non-terminal (two-way SENT) row past its expiry must be force-updated to EXPIRED on reload:
+        ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
+        verify(rpcService).update(eq(tenantId), captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(RpcStatus.EXPIRED);
+    }
+
+    @Test
     public void seedsCounterPastHighestReloadedId() {
-        TbRpcService rpcService = mock(TbRpcService.class);
-        willReturn(rpcService).given(systemContext).getTbRpcService();
-        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
-        willReturn("svc").given(systemContext).getServiceId();
+        mockRpcInfra();
+        stubInFlight(inFlightRow(RpcStatus.SENT, 5, System.currentTimeMillis()));
 
-        Rpc row = new Rpc(new RpcId(UUID.randomUUID()));
-        row.setCreatedTime(System.currentTimeMillis());
-        row.setExpirationTime(System.currentTimeMillis() + 60_000);
-        row.setStatus(RpcStatus.SENT);
-        row.setRequestId(5);
-        row.setRequest(JacksonUtil.valueToTree(new ToDeviceRpcRequest(row.getUuidId(), tenantId, deviceId,
-                false, row.getExpirationTime(), new ToDeviceRpcRequestBody("m", "{}"), true, null, null)));
-        stubReload(rpcService, RpcStatus.QUEUED); // empty
-        stubReload(rpcService, RpcStatus.DELIVERED); // empty
-        willReturn(new PageData<>(List.of(row), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.SENT), any());
-
-        TbActorCtx ctx = mock(TbActorCtx.class);
-        processor.init(ctx);
+        processor.init(mock(TbActorCtx.class));
 
         // next brand-new persistent RPC must get id 6, not 0:
         ToDeviceRpcRequest req = new ToDeviceRpcRequest(UUID.randomUUID(), tenantId, deviceId, false,
                 System.currentTimeMillis() + 60_000, new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
-        processor.processRpcRequest(ctx, new ToDeviceRpcRequestActorMsg("svc", req));
+        processor.processRpcRequest(mock(TbActorCtx.class), new ToDeviceRpcRequestActorMsg("svc", req));
 
         ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
         verify(rpcService).create(eq(tenantId), captor.capture());
@@ -230,119 +189,58 @@ public class DeviceActorMessageProcessorTest {
 
     @Test
     public void resubscribeReSendsUndeliveredButNotDelivered() {
-        TbRpcService rpcService = mock(TbRpcService.class);
-        willReturn(rpcService).given(systemContext).getTbRpcService();
-        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
-        willReturn("svc").given(systemContext).getServiceId();
-        TbCoreToTransportService toTransport = mock(TbCoreToTransportService.class);
-        willReturn(toTransport).given(systemContext).getTbCoreToTransportService();
-
-        Rpc sent = inFlightRow(RpcStatus.SENT, 6, 1000L);        // undelivered
-        Rpc delivered = inFlightRow(RpcStatus.DELIVERED, 5, 2000L);
-        stubReload(rpcService, RpcStatus.QUEUED);
-        willReturn(new PageData<>(List.of(sent), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.SENT), any());
-        willReturn(new PageData<>(List.of(delivered), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.DELIVERED), any());
+        mockRpcInfra();
+        stubInFlight(inFlightRow(RpcStatus.SENT, 6, 1000L),          // undelivered
+                inFlightRow(RpcStatus.DELIVERED, 5, 2000L));
         processor.init(mock(TbActorCtx.class));
 
-        // seed an ASYNC session so sendPendingRequests takes the forEach branch, then push directly:
-        UUID sessionId = UUID.randomUUID();
-        SessionInfo sessionInfo = new SessionInfo(SessionType.ASYNC, "svc");
-        processor.sessions.put(sessionId, new SessionInfoMetaData(sessionInfo));
-        processor.rpcSubscriptions.put(sessionId, sessionInfo);
-        processor.sendPendingRequests(sessionId, "svc");
+        pushViaAsyncSession();
 
-        // sendToTransport wraps the request in a ToTransportMsg and calls the 2-arg process(nodeId, msg):
-        ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
-        verify(toTransport, atLeastOnce()).process(any(), captor.capture());
-        assertThat(captor.getAllValues())
-                .extracting(m -> m.getToDeviceRequest().getRequestId())
-                .contains(6).doesNotContain(5); // undelivered re-sent, delivered not
+        // undelivered re-sent, delivered not:
+        assertThat(publishedRequestIds()).contains(6).doesNotContain(5);
     }
 
     @Test
     public void oneWaySentRowIsRePublishedOnReload() {
-        TbRpcService rpcService = mock(TbRpcService.class);
-        willReturn(rpcService).given(systemContext).getTbRpcService();
-        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
-        willReturn("svc").given(systemContext).getServiceId();
-        TbCoreToTransportService toTransport = mock(TbCoreToTransportService.class);
-        willReturn(toTransport).given(systemContext).getTbCoreToTransportService();
-
-        Rpc onewaySent = inFlightRow(RpcStatus.SENT, 6, 1000L, true); // one-way, QoS-1 publish->PUBACK window
-        stubReload(rpcService, RpcStatus.QUEUED);
-        stubReload(rpcService, RpcStatus.DELIVERED);
-        willReturn(new PageData<>(List.of(onewaySent), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.SENT), any());
+        mockRpcInfra();
+        stubInFlight(inFlightRow(RpcStatus.SENT, 6, 1000L, true)); // one-way, QoS-1 publish->PUBACK window
         processor.init(mock(TbActorCtx.class));
 
-        // seed an ASYNC session so sendPendingRequests takes the forEach branch, then push directly:
-        UUID sessionId = UUID.randomUUID();
-        SessionInfo sessionInfo = new SessionInfo(SessionType.ASYNC, "svc");
-        processor.sessions.put(sessionId, new SessionInfoMetaData(sessionInfo));
-        processor.rpcSubscriptions.put(sessionId, sessionInfo);
-        processor.sendPendingRequests(sessionId, "svc");
+        pushViaAsyncSession();
 
         // one-way SENT is no longer skipped on reload — it must be re-published to the device:
-        ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
-        verify(toTransport, atLeastOnce()).process(any(), captor.capture());
-        assertThat(captor.getAllValues())
-                .extracting(m -> m.getToDeviceRequest().getRequestId())
-                .contains(6);
+        assertThat(publishedRequestIds()).contains(6);
     }
 
     @Test
     public void legacyNullRequestIdRowReloadsWithoutNpe() {
-        TbRpcService rpcService = mock(TbRpcService.class);
-        willReturn(rpcService).given(systemContext).getTbRpcService();
-        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
-        willReturn("svc").given(systemContext).getServiceId();
-        TbCoreToTransportService toTransport = mock(TbCoreToTransportService.class);
-        willReturn(toTransport).given(systemContext).getTbCoreToTransportService();
+        mockRpcInfra();
+        stubInFlight(legacyQueuedRow(System.currentTimeMillis())); // legacy pre-migration row: null requestId
+        processor.init(mock(TbActorCtx.class)); // must not NPE despite the null persisted requestId
 
-        UUID rpcUuid = UUID.randomUUID();
-        long exp = System.currentTimeMillis() + 60_000;
-        ToDeviceRpcRequest req = new ToDeviceRpcRequest(rpcUuid, tenantId, deviceId, false, exp,
-                new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
-        Rpc legacyRow = new Rpc(new RpcId(rpcUuid));
-        legacyRow.setCreatedTime(System.currentTimeMillis());
-        legacyRow.setExpirationTime(exp);
-        legacyRow.setStatus(RpcStatus.QUEUED);
-        legacyRow.setRequestId(null); // legacy pre-migration row: no persisted requestId
-        legacyRow.setRequest(JacksonUtil.valueToTree(req));
-
-        willReturn(new PageData<>(List.of(legacyRow), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.QUEUED), any());
-        stubReload(rpcService, RpcStatus.SENT);
-        stubReload(rpcService, RpcStatus.DELIVERED);
-
-        TbActorCtx ctx = mock(TbActorCtx.class);
-        processor.init(ctx); // must not NPE despite the null persisted requestId
-
-        UUID sessionId = UUID.randomUUID();
-        SessionInfo sessionInfo = new SessionInfo(SessionType.ASYNC, "svc");
-        processor.sessions.put(sessionId, new SessionInfoMetaData(sessionInfo));
-        processor.rpcSubscriptions.put(sessionId, sessionInfo);
-        processor.sendPendingRequests(sessionId, "svc");
+        pushViaAsyncSession();
 
         // fresh-id fallback (rpcSeq, starting at 0) was assigned and the row was registered/re-published:
-        ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
-        verify(toTransport, atLeastOnce()).process(any(), captor.capture());
-        assertThat(captor.getAllValues())
-                .extracting(m -> m.getToDeviceRequest().getRequestId())
-                .contains(0);
+        assertThat(publishedRequestIds()).contains(0);
+    }
+
+    @Test
+    public void legacyNullAndReusedIdDoNotCollideOnReload() {
+        mockRpcInfra();
+        // a legacy row (null id, older) and a post-migration row that reused id 0 (newer) in the SAME batch:
+        stubInFlight(legacyQueuedRow(1000L), inFlightRow(RpcStatus.QUEUED, 0, 2000L));
+
+        processor.init(mock(TbActorCtx.class));
+        pushViaAsyncSession();
+
+        // the legacy row's fallback id must be seeded past the reused id 0, so both re-publish under distinct
+        // ids (0 stays 0, the legacy row gets 1) — neither clobbers the other in the pending map:
+        assertThat(publishedRequestIds()).containsExactlyInAnyOrder(0, 1);
     }
 
     @Test
     public void nullRequestRowIsSkippedWithoutAbortingReload() {
-        TbRpcService rpcService = mock(TbRpcService.class);
-        willReturn(rpcService).given(systemContext).getTbRpcService();
-        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
-        willReturn("svc").given(systemContext).getServiceId();
-        TbCoreToTransportService toTransport = mock(TbCoreToTransportService.class);
-        willReturn(toTransport).given(systemContext).getTbCoreToTransportService();
-
+        mockRpcInfra();
         // corrupt/legacy row whose request JSON deserializes to null — processed FIRST (earlier createdTime):
         Rpc badRow = new Rpc(new RpcId(UUID.randomUUID()));
         badRow.setCreatedTime(999L);
@@ -350,27 +248,44 @@ public class DeviceActorMessageProcessorTest {
         badRow.setStatus(RpcStatus.QUEUED);
         badRow.setRequestId(7);
         badRow.setRequest(null); // JacksonUtil.convertValue(null, ...) returns null -> restore must skip, not NPE
-        Rpc goodRow = inFlightRow(RpcStatus.QUEUED, 9, 1000L);
-        willReturn(new PageData<>(List.of(badRow, goodRow), 1, 0, false)).given(rpcService)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.QUEUED), any());
-        stubReload(rpcService, RpcStatus.SENT);
-        stubReload(rpcService, RpcStatus.DELIVERED);
+        stubInFlight(badRow, inFlightRow(RpcStatus.QUEUED, 9, 1000L));
 
         processor.init(mock(TbActorCtx.class)); // must not NPE on the null-request row
 
+        pushViaAsyncSession();
+
+        // the bad row is silently skipped; the following good row still restores and re-publishes:
+        assertThat(publishedRequestIds()).contains(9).doesNotContain(7);
+    }
+
+    private void mockRpcInfra() {
+        rpcService = mock(TbRpcService.class);
+        willReturn(rpcService).given(systemContext).getTbRpcService();
+        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
+        willReturn("svc").given(systemContext).getServiceId();
+        toTransport = mock(TbCoreToTransportService.class);
+        willReturn(toTransport).given(systemContext).getTbCoreToTransportService();
+    }
+
+    // The reload issues a single findAllByDeviceIdAndStatusIn query; the actor sorts the rows itself, so the
+    // stub just returns them all in one page regardless of order.
+    private void stubInFlight(Rpc... rows) {
+        willReturn(new PageData<>(List.of(rows), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatusIn(eq(tenantId), eq(deviceId), any(), any());
+    }
+
+    private void pushViaAsyncSession() {
         UUID sessionId = UUID.randomUUID();
         SessionInfo sessionInfo = new SessionInfo(SessionType.ASYNC, "svc");
         processor.sessions.put(sessionId, new SessionInfoMetaData(sessionInfo));
         processor.rpcSubscriptions.put(sessionId, sessionInfo);
         processor.sendPendingRequests(sessionId, "svc");
+    }
 
-        // the bad row is silently skipped; the following good row still restores and re-publishes:
+    private List<Integer> publishedRequestIds() {
         ArgumentCaptor<ToTransportMsg> captor = ArgumentCaptor.forClass(ToTransportMsg.class);
         verify(toTransport, atLeastOnce()).process(any(), captor.capture());
-        assertThat(captor.getAllValues())
-                .extracting(m -> m.getToDeviceRequest().getRequestId())
-                .contains(9)
-                .doesNotContain(7);
+        return captor.getAllValues().stream().map(m -> m.getToDeviceRequest().getRequestId()).toList();
     }
 
     private Rpc inFlightRow(RpcStatus status, int requestId, long createdTime) {
@@ -378,22 +293,33 @@ public class DeviceActorMessageProcessorTest {
     }
 
     private Rpc inFlightRow(RpcStatus status, int requestId, long createdTime, boolean oneway) {
-        UUID rpcUuid = UUID.randomUUID();
         long exp = System.currentTimeMillis() + 60_000;
-        ToDeviceRpcRequest req = new ToDeviceRpcRequest(rpcUuid, tenantId, deviceId, oneway, exp,
-                new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
-        Rpc rpc = new Rpc(new RpcId(rpcUuid));
-        rpc.setCreatedTime(createdTime);
-        rpc.setExpirationTime(exp);
-        rpc.setStatus(status);
+        Rpc rpc = row(UUID.randomUUID(), status, createdTime, exp, oneway);
         rpc.setRequestId(requestId);
-        rpc.setRequest(JacksonUtil.valueToTree(req));
         return rpc;
     }
 
-    private void stubReload(TbRpcService s, RpcStatus st) {
-        willReturn(new PageData<>(List.of(), 1, 0, false)).given(s)
-                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(st), any());
+    private Rpc expiredRow(RpcStatus status, int requestId, boolean oneway, long pastExp) {
+        Rpc rpc = row(UUID.randomUUID(), status, System.currentTimeMillis() - 120_000, pastExp, oneway);
+        rpc.setRequestId(requestId);
+        return rpc;
+    }
+
+    private Rpc legacyQueuedRow(long createdTime) {
+        Rpc rpc = row(UUID.randomUUID(), RpcStatus.QUEUED, createdTime, System.currentTimeMillis() + 60_000, false);
+        rpc.setRequestId(null); // pre-migration row: no persisted requestId
+        return rpc;
+    }
+
+    private Rpc row(UUID rpcUuid, RpcStatus status, long createdTime, long expirationTime, boolean oneway) {
+        ToDeviceRpcRequest req = new ToDeviceRpcRequest(rpcUuid, tenantId, deviceId, oneway, expirationTime,
+                new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
+        Rpc rpc = new Rpc(new RpcId(rpcUuid));
+        rpc.setCreatedTime(createdTime);
+        rpc.setExpirationTime(expirationTime);
+        rpc.setStatus(status);
+        rpc.setRequest(JacksonUtil.valueToTree(req));
+        return rpc;
     }
 
     private SessionInfoProto sessionInfoProto() {

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -168,6 +168,33 @@ public class DeviceActorMessageProcessorTest {
     }
 
     @Test
+    public void pastExpiryTimeoutRowIsExpiredOnReload() {
+        mockRpcInfra();
+        long pastExp = System.currentTimeMillis() - 60_000; // already expired
+        Rpc row = expiredRow(RpcStatus.TIMEOUT, 4, false /*two-way*/, pastExp);
+        stubInFlight(row);
+
+        processor.init(mock(TbActorCtx.class));
+
+        // a reloaded TIMEOUT row (delivery ack timed out, mid-retry) past its expiry must be force-closed to EXPIRED:
+        ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
+        verify(rpcService).update(eq(tenantId), captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(RpcStatus.EXPIRED);
+    }
+
+    @Test
+    public void inFlightTimeoutRowIsReTrackedNotExpiredOnReload() {
+        mockRpcInfra();
+        Rpc row = inFlightRow(RpcStatus.TIMEOUT, 8, System.currentTimeMillis());
+        stubInFlight(row);
+
+        processor.init(mock(TbActorCtx.class));
+
+        // a not-yet-expired TIMEOUT row is re-tracked for retry, not force-closed: no terminal update on reload
+        verify(rpcService, never()).update(any(), any());
+    }
+
+    @Test
     public void seedsCounterPastHighestReloadedId() {
         mockRpcInfra();
         stubInFlight(inFlightRow(RpcStatus.SENT, 5, System.currentTimeMillis()));

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -17,12 +17,20 @@ package org.thingsboard.server.actors.device;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.thingsboard.common.util.LinkedHashMapRemoveEldest;
 import org.thingsboard.server.actors.ActorSystemContext;
+import org.thingsboard.server.actors.TbActorCtx;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.rpc.Rpc;
+import org.thingsboard.server.common.data.rpc.ToDeviceRpcRequestBody;
+import org.thingsboard.server.common.msg.rpc.ToDeviceRpcRequest;
+import org.thingsboard.server.common.msg.rpc.ToDeviceRpcRequestActorMsg;
 import org.thingsboard.server.dao.device.DeviceService;
+import org.thingsboard.server.service.rpc.TbCoreDeviceRpcService;
+import org.thingsboard.server.service.rpc.TbRpcService;
 import org.thingsboard.server.service.transport.TbCoreToTransportService;
 
 import java.util.UUID;
@@ -31,9 +39,11 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class DeviceActorMessageProcessorTest {
 
@@ -51,6 +61,7 @@ public class DeviceActorMessageProcessorTest {
         deviceService = mock(DeviceService.class);
         willReturn(MAX_CONCURRENT_SESSIONS_PER_DEVICE).given(systemContext).getMaxConcurrentSessionsPerDevice();
         willReturn(deviceService).given(systemContext).getDeviceService();
+        willReturn("BURST").given(systemContext).getRpcSubmitStrategy();
         processor = new DeviceActorMessageProcessor(systemContext, tenantId, deviceId);
         willReturn(mock(TbCoreToTransportService.class)).given(systemContext).getTbCoreToTransportService();
     }
@@ -82,5 +93,22 @@ public class DeviceActorMessageProcessorTest {
         assertThat(processor.attributeSubscriptions.size(), is(MAX_CONCURRENT_SESSIONS_PER_DEVICE-1));
         assertThat(processor.rpcSubscriptions.size(), is(MAX_CONCURRENT_SESSIONS_PER_DEVICE-1));
 
+    }
+
+    @Test
+    public void persistsRequestIdOnCreate() {
+        TbRpcService rpcService = mock(TbRpcService.class);
+        willReturn(rpcService).given(systemContext).getTbRpcService();
+        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
+
+        TbActorCtx ctx = mock(TbActorCtx.class);
+        ToDeviceRpcRequest request = new ToDeviceRpcRequest(UUID.randomUUID(), tenantId, deviceId,
+                false, System.currentTimeMillis() + 60_000, new ToDeviceRpcRequestBody("m", "{}"),
+                true, null, null); // persisted=true, oneway=false
+        processor.processRpcRequest(ctx, new ToDeviceRpcRequestActorMsg("svc", request));
+
+        ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
+        verify(rpcService).create(eq(tenantId), captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getRequestId()).isEqualTo(0); // first rpcSeq
     }
 }

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -45,16 +45,13 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class DeviceActorMessageProcessorTest {
@@ -73,18 +70,18 @@ public class DeviceActorMessageProcessorTest {
     public void setUp() {
         systemContext = mock(ActorSystemContext.class);
         deviceService = mock(DeviceService.class);
-        willReturn(MAX_CONCURRENT_SESSIONS_PER_DEVICE).given(systemContext).getMaxConcurrentSessionsPerDevice();
-        willReturn(deviceService).given(systemContext).getDeviceService();
-        willReturn("BURST").given(systemContext).getRpcSubmitStrategy();
+        given(systemContext.getMaxConcurrentSessionsPerDevice()).willReturn(MAX_CONCURRENT_SESSIONS_PER_DEVICE);
+        given(systemContext.getDeviceService()).willReturn(deviceService);
+        given(systemContext.getRpcSubmitStrategy()).willReturn("BURST");
         processor = new DeviceActorMessageProcessor(systemContext, tenantId, deviceId);
-        willReturn(mock(TbCoreToTransportService.class)).given(systemContext).getTbCoreToTransportService();
+        given(systemContext.getTbCoreToTransportService()).willReturn(mock(TbCoreToTransportService.class));
     }
 
     @Test
     public void givenSystemContext_whenNewInstance_thenVerifySessionMapMaxSize() {
-        assertThat(processor.sessions, instanceOf(LinkedHashMapRemoveEldest.class));
-        assertThat(processor.sessions.getMaxEntries(), is(MAX_CONCURRENT_SESSIONS_PER_DEVICE));
-        assertThat(processor.sessions.getRemovalConsumer(), notNullValue());
+        assertThat(processor.sessions).isInstanceOf(LinkedHashMapRemoveEldest.class);
+        assertThat(processor.sessions.getMaxEntries()).isEqualTo(MAX_CONCURRENT_SESSIONS_PER_DEVICE);
+        assertThat(processor.sessions.getRemovalConsumer()).isNotNull();
     }
 
     @Test
@@ -96,16 +93,16 @@ public class DeviceActorMessageProcessorTest {
             processor.attributeSubscriptions.put(sessionID, Mockito.mock(SessionInfo.class));
             processor.rpcSubscriptions.put(sessionID, Mockito.mock(SessionInfo.class));
         }
-        assertThat(processor.sessions.size(), is(MAX_CONCURRENT_SESSIONS_PER_DEVICE));
-        assertThat(processor.attributeSubscriptions.size(), is(MAX_CONCURRENT_SESSIONS_PER_DEVICE));
-        assertThat(processor.rpcSubscriptions.size(), is(MAX_CONCURRENT_SESSIONS_PER_DEVICE));
+        assertThat(processor.sessions.size()).isEqualTo(MAX_CONCURRENT_SESSIONS_PER_DEVICE);
+        assertThat(processor.attributeSubscriptions.size()).isEqualTo(MAX_CONCURRENT_SESSIONS_PER_DEVICE);
+        assertThat(processor.rpcSubscriptions.size()).isEqualTo(MAX_CONCURRENT_SESSIONS_PER_DEVICE);
 
         //add one more
         processor.sessions.put(UUID.randomUUID(), Mockito.mock(SessionInfoMetaData.class));
 
-        assertThat(processor.sessions.size(), is(MAX_CONCURRENT_SESSIONS_PER_DEVICE));
-        assertThat(processor.attributeSubscriptions.size(), is(MAX_CONCURRENT_SESSIONS_PER_DEVICE-1));
-        assertThat(processor.rpcSubscriptions.size(), is(MAX_CONCURRENT_SESSIONS_PER_DEVICE-1));
+        assertThat(processor.sessions.size()).isEqualTo(MAX_CONCURRENT_SESSIONS_PER_DEVICE);
+        assertThat(processor.attributeSubscriptions.size()).isEqualTo(MAX_CONCURRENT_SESSIONS_PER_DEVICE - 1);
+        assertThat(processor.rpcSubscriptions.size()).isEqualTo(MAX_CONCURRENT_SESSIONS_PER_DEVICE - 1);
 
     }
 
@@ -152,7 +149,7 @@ public class DeviceActorMessageProcessorTest {
         processor.init(mock(TbActorCtx.class));
 
         // terminal one-way DELIVERED row, past expiry: must be left untouched, no EXPIRED overwrite
-        Mockito.verify(rpcService, Mockito.never()).update(any(), any());
+        verify(rpcService, never()).update(any(), any());
     }
 
     @Test
@@ -274,24 +271,24 @@ public class DeviceActorMessageProcessorTest {
         verify(rpcService).update(eq(tenantId), captor.capture());
         assertThat(captor.getValue().getStatus()).isEqualTo(RpcStatus.FAILED);
         assertThat(captor.getValue().getResponse()).isNotNull();
-        Mockito.verify(toTransport, Mockito.never()).process(any(), any());
+        verify(toTransport, never()).process(any(), any());
     }
 
     private void mockRpcInfra() {
         rpcService = mock(TbRpcService.class);
-        willReturn(rpcService).given(systemContext).getTbRpcService();
-        willReturn(mock(TbCoreDeviceRpcService.class)).given(systemContext).getTbCoreDeviceRpcService();
-        willReturn("svc").given(systemContext).getServiceId();
+        given(systemContext.getTbRpcService()).willReturn(rpcService);
+        given(systemContext.getTbCoreDeviceRpcService()).willReturn(mock(TbCoreDeviceRpcService.class));
+        given(systemContext.getServiceId()).willReturn("svc");
         toTransport = mock(TbCoreToTransportService.class);
-        willReturn(toTransport).given(systemContext).getTbCoreToTransportService();
+        given(systemContext.getTbCoreToTransportService()).willReturn(toTransport);
     }
 
     // The reload issues a single findInFlightForReload query (DB-side filters out one-way DELIVERED and
     // terminal statuses - see JpaRpcDaoTest); the actor sorts the rows itself, so the stub just returns
     // them all in one page regardless of order.
     private void stubInFlight(Rpc... rows) {
-        willReturn(new PageData<>(List.of(rows), 1, 0, false)).given(rpcService)
-                .findInFlightForReload(eq(tenantId), eq(deviceId), any());
+        given(rpcService.findInFlightForReload(eq(tenantId), eq(deviceId), any()))
+                .willReturn(new PageData<>(List.of(rows), 1, 0, false));
     }
 
     private void pushViaAsyncSession() {

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -19,26 +19,34 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.common.util.LinkedHashMapRemoveEldest;
 import org.thingsboard.server.actors.ActorSystemContext;
 import org.thingsboard.server.actors.TbActorCtx;
 import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.RpcId;
 import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.rpc.Rpc;
+import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.common.data.rpc.ToDeviceRpcRequestBody;
 import org.thingsboard.server.common.msg.rpc.ToDeviceRpcRequest;
 import org.thingsboard.server.common.msg.rpc.ToDeviceRpcRequestActorMsg;
 import org.thingsboard.server.dao.device.DeviceService;
+import org.thingsboard.server.gen.transport.TransportProtos.SessionInfoProto;
+import org.thingsboard.server.gen.transport.TransportProtos.ToDeviceRpcResponseMsg;
 import org.thingsboard.server.service.rpc.TbCoreDeviceRpcService;
 import org.thingsboard.server.service.rpc.TbRpcService;
 import org.thingsboard.server.service.transport.TbCoreToTransportService;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -110,5 +118,53 @@ public class DeviceActorMessageProcessorTest {
         ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
         verify(rpcService).create(eq(tenantId), captor.capture());
         org.assertj.core.api.Assertions.assertThat(captor.getValue().getRequestId()).isEqualTo(0); // first rpcSeq
+    }
+
+    @Test
+    public void reloadedDeliveredRpcMatchesDeviceResponse() {
+        TbRpcService rpcService = mock(TbRpcService.class);
+        willReturn(rpcService).given(systemContext).getTbRpcService();
+        TbCoreDeviceRpcService coreRpc = mock(TbCoreDeviceRpcService.class);
+        willReturn(coreRpc).given(systemContext).getTbCoreDeviceRpcService();
+        willReturn("svc").given(systemContext).getServiceId();
+
+        UUID rpcUuid = UUID.randomUUID();
+        ToDeviceRpcRequest req = new ToDeviceRpcRequest(rpcUuid, tenantId, deviceId, false,
+                System.currentTimeMillis() + 60_000, new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
+        Rpc row = new Rpc(new RpcId(rpcUuid));
+        row.setCreatedTime(System.currentTimeMillis());
+        row.setExpirationTime(System.currentTimeMillis() + 60_000);
+        row.setStatus(RpcStatus.DELIVERED);
+        row.setRequestId(7);
+        row.setRequest(JacksonUtil.valueToTree(req));
+
+        // QUEUED/SENT empty, DELIVERED returns our row:
+        willReturn(new PageData<>(List.of(), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.QUEUED), any());
+        willReturn(new PageData<>(List.of(), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.SENT), any());
+        willReturn(new PageData<>(List.of(row), 1, 0, false)).given(rpcService)
+                .findAllByDeviceIdAndStatus(eq(tenantId), eq(deviceId), eq(RpcStatus.DELIVERED), any());
+
+        TbActorCtx ctx = mock(TbActorCtx.class);
+        processor.init(ctx);
+
+        // device replies with the OLD id 7:
+        processor.processRpcResponses(sessionInfoProto(), ToDeviceRpcResponseMsg.newBuilder()
+                .setRequestId(7).setPayload("{\"ok\":true}").build());
+
+        // matched → row updated to SUCCESSFUL (not "stale"):
+        ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
+        verify(rpcService).update(eq(tenantId), captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getStatus()).isEqualTo(RpcStatus.SUCCESSFUL);
+    }
+
+    private SessionInfoProto sessionInfoProto() {
+        UUID sid = UUID.randomUUID();
+        return SessionInfoProto.newBuilder()
+                .setNodeId("svc")
+                .setSessionIdMSB(sid.getMostSignificantBits())
+                .setSessionIdLSB(sid.getLeastSignificantBits())
+                .build();
     }
 }

--- a/application/src/test/java/org/thingsboard/server/service/install/lts/LtsMigrationIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/install/lts/LtsMigrationIntegrationTest.java
@@ -127,7 +127,7 @@ public class LtsMigrationIntegrationTest extends AbstractControllerTest {
 
     @Test
     public void appliesSqlDeprecatesTypesDeletesBundleAndRecordsVersion() {
-        ltsMigrationService.applyMigrations("4.2.2.2", "4.2.2.3");
+        ltsMigrationService.applyMigrations("4.2.2.2", "4.2.2.3", () -> {});
 
         // 1. The version's SQL ran: iot_hub_installed_item table now exists.
         assertTrue(tableExists("iot_hub_installed_item"));
@@ -144,9 +144,9 @@ public class LtsMigrationIntegrationTest extends AbstractControllerTest {
 
     @Test
     public void reRunFromCurrentVersionIsNoOp() {
-        ltsMigrationService.applyMigrations("4.2.2.2", "4.2.2.3");
+        ltsMigrationService.applyMigrations("4.2.2.2", "4.2.2.3", () -> {});
         // Re-running from the now-current version selects an empty range — nothing changes, nothing throws.
-        ltsMigrationService.applyMigrations("4.2.2.3", "4.2.2.3");
+        ltsMigrationService.applyMigrations("4.2.2.3", "4.2.2.3", () -> {});
 
         assertEquals(Long.valueOf(V_4_2_2_3),
                 jdbcTemplate.queryForObject("SELECT schema_version FROM tb_schema_settings", Long.class));
@@ -183,7 +183,7 @@ public class LtsMigrationIntegrationTest extends AbstractControllerTest {
         assertFalse(columnExists("calculated_field", "additional_info"));
 
         // Drive the runner over a range whose target (4.3.1.2) selects only the 4.3.1.2 migration.
-        ltsMigrationService.applyMigrations("4.3.1.1", "4.3.1.2");
+        ltsMigrationService.applyMigrations("4.3.1.1", "4.3.1.2", () -> {});
 
         // The 4.3.1.2 schema SQL ran: the column exists again.
         assertTrue(columnExists("calculated_field", "additional_info"));

--- a/application/src/test/java/org/thingsboard/server/service/install/lts/LtsMigrationServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/install/lts/LtsMigrationServiceTest.java
@@ -231,6 +231,19 @@ class LtsMigrationServiceTest {
     }
 
     @Test
+    void runDataMigrationsAppliesAndAppliesAfterCommitButNeverRunsSqlOrRecords() throws Exception {
+        List<String> sequence = new ArrayList<>();
+        writeSql("4.2.2.3", "SELECT 1;");
+        LtsMigrationService service = service(List.of(migrationWithAfterCommit("4.2.2.3", sequence)));
+
+        service.runDataMigrations("4.2.2.2", "4.2.2.3");
+
+        assertEquals(List.of("apply(4.2.2.3)", "applyAfterCommit(4.2.2.3)"), sequence);
+        verify(jdbcTemplate, never()).execute(anyString());
+        verify(schemaSettingsService, never()).updateSchemaVersion(anyString());
+    }
+
+    @Test
     void migrationWithoutSqlFileStillAppliesAndRecords() {
         List<String> applied = new ArrayList<>();
         LtsMigrationService service = service(List.of(migration("4.2.2.3", applied)));

--- a/application/src/test/java/org/thingsboard/server/service/install/lts/LtsMigrationServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/install/lts/LtsMigrationServiceTest.java
@@ -74,6 +74,15 @@ class LtsMigrationServiceTest {
         };
     }
 
+    /** Records apply() and applyAfterCommit() calls (distinctly tagged) into a single shared ordered list. */
+    private LtsMigration migrationWithAfterCommit(String version, List<String> sequence) {
+        return new LtsMigration() {
+            @Override public String getVersion() { return version; }
+            @Override public void apply() { sequence.add("apply(" + version + ")"); }
+            @Override public void applyAfterCommit() { sequence.add("applyAfterCommit(" + version + ")"); }
+        };
+    }
+
     private LtsMigrationService service(List<LtsMigration> migrations) {
         return new LtsMigrationService(jdbcTemplate, installScripts, schemaSettingsService, txManager, migrations);
     }
@@ -244,5 +253,35 @@ class LtsMigrationServiceTest {
     void failsLoudOnUnparseableVersion() {
         List<String> applied = new ArrayList<>();
         assertThrows(IllegalArgumentException.class, () -> service(List.of(migration("nope", applied))));
+    }
+
+    @Test
+    void applyMigrationsRunsAllApplyThenAfterSchemaPhaseThenAllApplyAfterCommit() {
+        List<String> sequence = new ArrayList<>();
+        LtsMigrationService service = service(List.of(
+                migrationWithAfterCommit("4.2.2.3", sequence),
+                migrationWithAfterCommit("4.2.2.4", sequence)));
+        Runnable afterSchemaPhase = () -> sequence.add("afterSchemaPhase");
+
+        service.applyMigrations("4.2.2.2", "4.2.2.4", afterSchemaPhase);
+
+        assertEquals(List.of(
+                "apply(4.2.2.3)", "apply(4.2.2.4)",
+                "afterSchemaPhase",
+                "applyAfterCommit(4.2.2.3)", "applyAfterCommit(4.2.2.4)"), sequence);
+    }
+
+    @Test
+    void applyMigrationsDoesNotRecordVersionWhenApplyAfterCommitFails() {
+        LtsMigration failing = new LtsMigration() {
+            @Override public String getVersion() { return "4.2.2.3"; }
+            @Override public void applyAfterCommit() { throw new RuntimeException("backfill failed"); }
+        };
+        LtsMigrationService service = service(List.of(failing));
+
+        assertThrows(RuntimeException.class,
+                () -> service.applyMigrations("4.2.2.2", "4.2.2.3", () -> {}));
+
+        verify(schemaSettingsService, never()).updateSchemaVersion(anyString());
     }
 }

--- a/application/src/test/java/org/thingsboard/server/service/install/lts/LtsMigrationServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/install/lts/LtsMigrationServiceTest.java
@@ -89,7 +89,7 @@ class LtsMigrationServiceTest {
                 migration("4.2.2.2", applied),
                 migration("4.2.2.3", applied)));
 
-        service.applyMigrations("4.2.2.2", "4.2.2.3");
+        service.applyMigrations("4.2.2.2", "4.2.2.3", () -> {});
 
         // only 4.2.2.3 is in (4.2.2.2, 4.2.2.3]
         assertEquals(List.of("4.2.2.3"), applied);
@@ -106,7 +106,7 @@ class LtsMigrationServiceTest {
         LtsMigrationService service = service(List.of(
                 migration("4.2.2.3", applied), migration("4.2.2.4", applied)));
 
-        service.applyMigrations("4.2.2.2", "4.2.2.4");
+        service.applyMigrations("4.2.2.2", "4.2.2.4", () -> {});
 
         assertEquals(List.of("4.2.2.3", "4.2.2.4"), applied);
         verify(jdbcTemplate).execute("SELECT 1;");
@@ -139,7 +139,7 @@ class LtsMigrationServiceTest {
                 migration("4.3.1.2", applied),
                 migration("4.3.1.3", applied)));
 
-        service.applyMigrations("4.2.2.2", "4.3.1.3");
+        service.applyMigrations("4.2.2.2", "4.3.1.3", () -> {});
 
         assertEquals(List.of("4.3.1.2", "4.3.1.3"), applied);
         verify(schemaSettingsService, never()).updateSchemaVersion("4.2.2.3");
@@ -188,7 +188,7 @@ class LtsMigrationServiceTest {
         writeSql("4.2.2.3", "SELECT 1;");
         LtsMigrationService service = service(List.of(migration("4.2.2.3", applied)));
 
-        service.applyMigrations("4.2.2.3", "4.2.2.3");
+        service.applyMigrations("4.2.2.3", "4.2.2.3", () -> {});
 
         assertEquals(List.of(), applied);
         verify(jdbcTemplate, never()).execute(anyString());
@@ -226,7 +226,7 @@ class LtsMigrationServiceTest {
         List<String> applied = new ArrayList<>();
         LtsMigrationService service = service(List.of(migration("4.2.2.3", applied)));
 
-        service.applyMigrations("4.2.2.2", "4.2.2.3");
+        service.applyMigrations("4.2.2.2", "4.2.2.3", () -> {});
 
         assertEquals(List.of("4.2.2.3"), applied);
         verify(jdbcTemplate, never()).execute(anyString());

--- a/application/src/test/java/org/thingsboard/server/service/install/lts/V4_3_1_4MigrationIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/install/lts/V4_3_1_4MigrationIntegrationTest.java
@@ -67,14 +67,15 @@ public class V4_3_1_4MigrationIntegrationTest extends AbstractControllerTest {
         long past = now - 60_000;
         long future = now + 60_000;
 
-        // Legacy (request_id IS NULL) rows the backfill MUST close -- 5 rows against a batch size of 2, so the
-        // loop must span 3 windows (2 + 2 + 1) for the cursor logic to be genuinely exercised.
+        // Legacy (request_id IS NULL) rows the backfill MUST close -- 6 rows against a batch size of 2, so the
+        // loop must span 3 windows (2 + 2 + 2) for the cursor logic to be genuinely exercised.
         List<UUID> stuck = List.of(
                 saveRpc(deviceId, UUID.fromString("9244c6c6-d932-43ca-91bb-b24482b08905"), "DELIVERED", false, past, null),
                 saveRpc(deviceId, UUID.fromString("c67c7357-1198-40f5-9d07-1a4a9f862720"), "DELIVERED", false, past, null),
                 saveRpc(deviceId, UUID.fromString("bde89223-7fe0-47e3-b190-88925ac7d070"), "DELIVERED", false, past, null),
                 saveRpc(deviceId, UUID.fromString("564b8b9d-5e06-4a71-b9d9-81b5b736595c"), "DELIVERED", false, past, null),
-                saveRpc(deviceId, UUID.fromString("31587a70-50c3-4f20-872c-70d4d3406a2d"), "SENT", true, past, null));
+                saveRpc(deviceId, UUID.fromString("31587a70-50c3-4f20-872c-70d4d3406a2d"), "SENT", true, past, null),
+                saveRpc(deviceId, UUID.fromString("1f6d2a4e-0c1b-4b7a-8e2d-2b9c7a1e6f30"), "TIMEOUT", false, past, null));
 
         // Rows the backfill MUST leave untouched.
         UUID oneWayDeliveredPastExpiry = saveRpc(deviceId, UUID.fromString("a553c35b-47a4-4906-825a-1be743e96d5d"), "DELIVERED", true, past, null); // terminal success

--- a/application/src/test/java/org/thingsboard/server/service/install/lts/V4_3_1_4MigrationIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/install/lts/V4_3_1_4MigrationIntegrationTest.java
@@ -19,8 +19,7 @@ import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.test.context.TestPropertySource;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.controller.AbstractControllerTest;
@@ -39,12 +38,13 @@ import static org.junit.Assert.assertNotNull;
  * termination) actually exercises more than one window -- not just the single-batch happy path.
  */
 @DaoSqlTest
+@TestPropertySource(properties = "install.rpc_legacy_cleanup_batch_size=2")
 public class V4_3_1_4MigrationIntegrationTest extends AbstractControllerTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
     @Autowired
-    private PlatformTransactionManager transactionManager;
+    private V4_3_1_4Migration migration;
 
     private final List<UUID> seededIds = new ArrayList<>();
 
@@ -58,12 +58,11 @@ public class V4_3_1_4MigrationIntegrationTest extends AbstractControllerTest {
 
     @Test
     public void batchLoopClosesAllStuckRowsAcrossMultipleWindowsAndLeavesOthersUntouched() {
-        V4_3_1_4Migration migration = new V4_3_1_4Migration(jdbcTemplate, transactionManager);
-        // Force a tiny batch size (< the 5 stuck rows seeded below) so applyAfterCommit() must run several
-        // keyset-paginated windows, proving the cursor actually advances across batches instead of just once.
-        ReflectionTestUtils.setField(migration, "batchSize", 2);
+        // batchSize is wired to 2 via the class-level @TestPropertySource (< the 5 stuck rows seeded below), so
+        // applyAfterCommit() must run several keyset-paginated windows, proving the cursor actually advances
+        // across batches instead of just once.
 
-        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        DeviceId deviceId = new DeviceId(UUID.fromString("39813cdc-a1ae-47c7-92af-25ec0a1fc303"));
         long now = System.currentTimeMillis();
         long past = now - 60_000;
         long future = now + 60_000;
@@ -71,17 +70,17 @@ public class V4_3_1_4MigrationIntegrationTest extends AbstractControllerTest {
         // Legacy (request_id IS NULL) rows the backfill MUST close -- 5 rows against a batch size of 2, so the
         // loop must span 3 windows (2 + 2 + 1) for the cursor logic to be genuinely exercised.
         List<UUID> stuck = List.of(
-                saveLegacy(deviceId, "DELIVERED", false, past, null),
-                saveLegacy(deviceId, "DELIVERED", false, past, null),
-                saveLegacy(deviceId, "DELIVERED", false, past, null),
-                saveLegacy(deviceId, "DELIVERED", false, past, null),
-                saveLegacy(deviceId, "SENT", true, past, null));
+                saveRpc(deviceId, UUID.fromString("9244c6c6-d932-43ca-91bb-b24482b08905"), "DELIVERED", false, past, null),
+                saveRpc(deviceId, UUID.fromString("c67c7357-1198-40f5-9d07-1a4a9f862720"), "DELIVERED", false, past, null),
+                saveRpc(deviceId, UUID.fromString("bde89223-7fe0-47e3-b190-88925ac7d070"), "DELIVERED", false, past, null),
+                saveRpc(deviceId, UUID.fromString("564b8b9d-5e06-4a71-b9d9-81b5b736595c"), "DELIVERED", false, past, null),
+                saveRpc(deviceId, UUID.fromString("31587a70-50c3-4f20-872c-70d4d3406a2d"), "SENT", true, past, null));
 
         // Rows the backfill MUST leave untouched.
-        UUID oneWayDeliveredPastExpiry = saveLegacy(deviceId, "DELIVERED", true, past, null); // terminal success
-        UUID twoWayDeliveredFutureExpiry = saveLegacy(deviceId, "DELIVERED", false, future, null); // not expired yet
-        UUID twoWayDeliveredWithRequestId = saveLegacy(deviceId, "DELIVERED", false, past, 7); // tracked, not legacy
-        UUID queuedPastExpiry = saveLegacy(deviceId, "QUEUED", false, past, null); // never sent
+        UUID oneWayDeliveredPastExpiry = saveRpc(deviceId, UUID.fromString("a553c35b-47a4-4906-825a-1be743e96d5d"), "DELIVERED", true, past, null); // terminal success
+        UUID twoWayDeliveredFutureExpiry = saveRpc(deviceId, UUID.fromString("acfd787f-86f3-4121-becb-e88eaa288934"), "DELIVERED", false, future, null); // not expired yet
+        UUID twoWayDeliveredWithRequestId = saveRpc(deviceId, UUID.fromString("ae7af8fc-7e58-492a-8c56-7453a48b3263"), "DELIVERED", false, past, 7); // tracked, not legacy
+        UUID queuedPastExpiry = saveRpc(deviceId, UUID.fromString("06129c0a-6654-49b0-938a-b87b79a8b7b7"), "QUEUED", false, past, null); // never sent
 
         migration.applyAfterCommit();
 
@@ -104,11 +103,10 @@ public class V4_3_1_4MigrationIntegrationTest extends AbstractControllerTest {
         return jdbcTemplate.queryForObject("SELECT response FROM rpc WHERE id = ?", String.class, id);
     }
 
-    // Seeds a legacy row (bypassing the entity/JPA layer to write raw request JSON) exactly as a pre-request_id
+    // Seeds an rpc row (bypassing the entity/JPA layer to write raw request JSON) exactly as a pre-request_id
     // server version would have left it: request_id NULL, request JSON carrying the oneway flag the migration's
     // CLEANUP_BATCH_SQL extracts via request::jsonb ->> 'oneway'.
-    private UUID saveLegacy(DeviceId deviceId, String status, boolean oneway, long expirationTime, Integer requestId) {
-        UUID id = UUID.randomUUID();
+    private UUID saveRpc(DeviceId deviceId, UUID id, String status, boolean oneway, long expirationTime, Integer requestId) {
         seededIds.add(id);
         String request = "{\"oneway\":" + oneway + ",\"method\":\"x\"}";
         jdbcTemplate.update("INSERT INTO rpc (id, created_time, tenant_id, device_id, expiration_time, request, " +

--- a/application/src/test/java/org/thingsboard/server/service/install/lts/V4_3_1_4MigrationIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/install/lts/V4_3_1_4MigrationIntegrationTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.install.lts;
+
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.controller.AbstractControllerTest;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Drives {@link V4_3_1_4Migration#applyAfterCommit()} against a real Postgres instance with a batch size far
+ * smaller than the legacy backlog seeded here, so the multi-batch keyset-pagination loop (cursor advance, guard,
+ * termination) actually exercises more than one window -- not just the single-batch happy path.
+ */
+@DaoSqlTest
+public class V4_3_1_4MigrationIntegrationTest extends AbstractControllerTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private final List<UUID> seededIds = new ArrayList<>();
+
+    @After
+    public void tearDown() {
+        if (!seededIds.isEmpty()) {
+            jdbcTemplate.batchUpdate("DELETE FROM rpc WHERE id = ?",
+                    seededIds.stream().map(id -> new Object[]{id}).toList());
+        }
+    }
+
+    @Test
+    public void batchLoopClosesAllStuckRowsAcrossMultipleWindowsAndLeavesOthersUntouched() {
+        V4_3_1_4Migration migration = new V4_3_1_4Migration(jdbcTemplate, transactionManager);
+        // Force a tiny batch size (< the 5 stuck rows seeded below) so applyAfterCommit() must run several
+        // keyset-paginated windows, proving the cursor actually advances across batches instead of just once.
+        ReflectionTestUtils.setField(migration, "batchSize", 2);
+
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        long now = System.currentTimeMillis();
+        long past = now - 60_000;
+        long future = now + 60_000;
+
+        // Legacy (request_id IS NULL) rows the backfill MUST close -- 5 rows against a batch size of 2, so the
+        // loop must span 3 windows (2 + 2 + 1) for the cursor logic to be genuinely exercised.
+        List<UUID> stuck = List.of(
+                saveLegacy(deviceId, "DELIVERED", false, past, null),
+                saveLegacy(deviceId, "DELIVERED", false, past, null),
+                saveLegacy(deviceId, "DELIVERED", false, past, null),
+                saveLegacy(deviceId, "DELIVERED", false, past, null),
+                saveLegacy(deviceId, "SENT", true, past, null));
+
+        // Rows the backfill MUST leave untouched.
+        UUID oneWayDeliveredPastExpiry = saveLegacy(deviceId, "DELIVERED", true, past, null); // terminal success
+        UUID twoWayDeliveredFutureExpiry = saveLegacy(deviceId, "DELIVERED", false, future, null); // not expired yet
+        UUID twoWayDeliveredWithRequestId = saveLegacy(deviceId, "DELIVERED", false, past, 7); // tracked, not legacy
+        UUID queuedPastExpiry = saveLegacy(deviceId, "QUEUED", false, past, null); // never sent
+
+        migration.applyAfterCommit();
+
+        for (UUID id : stuck) {
+            assertEquals("EXPIRED", statusOf(id));
+            assertNotNull(responseOf(id));
+        }
+
+        assertEquals("DELIVERED", statusOf(oneWayDeliveredPastExpiry));
+        assertEquals("DELIVERED", statusOf(twoWayDeliveredFutureExpiry));
+        assertEquals("DELIVERED", statusOf(twoWayDeliveredWithRequestId));
+        assertEquals("QUEUED", statusOf(queuedPastExpiry));
+    }
+
+    private String statusOf(UUID id) {
+        return jdbcTemplate.queryForObject("SELECT status FROM rpc WHERE id = ?", String.class, id);
+    }
+
+    private String responseOf(UUID id) {
+        return jdbcTemplate.queryForObject("SELECT response FROM rpc WHERE id = ?", String.class, id);
+    }
+
+    // Seeds a legacy row (bypassing the entity/JPA layer to write raw request JSON) exactly as a pre-request_id
+    // server version would have left it: request_id NULL, request JSON carrying the oneway flag the migration's
+    // CLEANUP_BATCH_SQL extracts via request::jsonb ->> 'oneway'.
+    private UUID saveLegacy(DeviceId deviceId, String status, boolean oneway, long expirationTime, Integer requestId) {
+        UUID id = UUID.randomUUID();
+        seededIds.add(id);
+        String request = "{\"oneway\":" + oneway + ",\"method\":\"x\"}";
+        jdbcTemplate.update("INSERT INTO rpc (id, created_time, tenant_id, device_id, expiration_time, request, " +
+                        "response, status, request_id, oneway) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)",
+                id, System.currentTimeMillis(), TenantId.SYS_TENANT_ID.getId(), deviceId.getId(), expirationTime,
+                request, status, requestId, oneway);
+        return id;
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/system/SystemPatchApplierTest.java
+++ b/application/src/test/java/org/thingsboard/server/system/SystemPatchApplierTest.java
@@ -474,7 +474,7 @@ public class SystemPatchApplierTest {
 
         ReflectionTestUtils.invokeMethod(reconciler, "applyPatchIfNeeded");
 
-        verify(ltsMigrationService).applyMigrations("4.3.0.0", "4.3.1.0");
+        verify(ltsMigrationService).applyMigrations(eq("4.3.0.0"), eq("4.3.1.0"), any());
         verify(schemaSettingsService).updateSchemaVersion();
     }
 
@@ -519,7 +519,7 @@ public class SystemPatchApplierTest {
         ReflectionTestUtils.invokeMethod(reconciler, "applyPatchIfNeeded");
 
         verify(schemaSettingsService).updateSchemaVersion();
-        verify(ltsMigrationService).applyMigrations("4.3.1.0", "4.3.2.0");
+        verify(ltsMigrationService).applyMigrations(eq("4.3.1.0"), eq("4.3.2.0"), any());
     }
 
     @Test

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/rpc/RpcService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/rpc/RpcService.java
@@ -25,6 +25,8 @@ import org.thingsboard.server.common.data.rpc.Rpc;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.dao.entity.EntityDaoService;
 
+import java.util.Collection;
+
 public interface RpcService extends EntityDaoService {
 
     Rpc save(Rpc rpc);
@@ -42,4 +44,6 @@ public interface RpcService extends EntityDaoService {
     PageData<Rpc> findAllByDeviceId(TenantId tenantId, DeviceId deviceId, PageLink pageLink);
 
     PageData<Rpc> findAllByDeviceIdAndStatus(TenantId tenantId, DeviceId deviceId, RpcStatus rpcStatus, PageLink pageLink);
+
+    PageData<Rpc> findAllByDeviceIdAndStatusIn(TenantId tenantId, DeviceId deviceId, Collection<RpcStatus> statuses, PageLink pageLink);
 }

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/rpc/RpcService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/rpc/RpcService.java
@@ -25,8 +25,6 @@ import org.thingsboard.server.common.data.rpc.Rpc;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.dao.entity.EntityDaoService;
 
-import java.util.Collection;
-
 public interface RpcService extends EntityDaoService {
 
     Rpc save(Rpc rpc);
@@ -45,5 +43,5 @@ public interface RpcService extends EntityDaoService {
 
     PageData<Rpc> findAllByDeviceIdAndStatus(TenantId tenantId, DeviceId deviceId, RpcStatus rpcStatus, PageLink pageLink);
 
-    PageData<Rpc> findAllByDeviceIdAndStatusIn(TenantId tenantId, DeviceId deviceId, Collection<RpcStatus> statuses, PageLink pageLink);
+    PageData<Rpc> findInFlightForReload(TenantId tenantId, DeviceId deviceId, PageLink pageLink);
 }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/rpc/Rpc.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/rpc/Rpc.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.common.data.rpc;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
@@ -44,7 +45,7 @@ public class Rpc extends BaseData<RpcId> implements HasTenantId {
     private RpcStatus status;
     @Schema(description = "Additional info used in the rule engine to process the updates to the RPC state.", accessMode = Schema.AccessMode.READ_ONLY)
     private JsonNode additionalInfo;
-    @Schema(description = "Transport request id used to correlate the device's response to this RPC.", accessMode = Schema.AccessMode.READ_ONLY)
+    @JsonIgnore // internal transport correlation id used only for actor-side recovery; kept out of the public API and rule-engine payload
     private Integer requestId;
 
     public Rpc() {

--- a/common/data/src/main/java/org/thingsboard/server/common/data/rpc/Rpc.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/rpc/Rpc.java
@@ -44,6 +44,7 @@ public class Rpc extends BaseData<RpcId> implements HasTenantId {
     private RpcStatus status;
     @Schema(description = "Additional info used in the rule engine to process the updates to the RPC state.", accessMode = Schema.AccessMode.READ_ONLY)
     private JsonNode additionalInfo;
+    private Integer requestId;
 
     public Rpc() {
         super();
@@ -62,6 +63,7 @@ public class Rpc extends BaseData<RpcId> implements HasTenantId {
         this.response = rpc.getResponse();
         this.status = rpc.getStatus();
         this.additionalInfo = rpc.getAdditionalInfo();
+        this.requestId = rpc.getRequestId();
     }
 
     @Schema(description = "JSON object with the rpc Id. Referencing non-existing rpc Id will cause error.")

--- a/common/data/src/main/java/org/thingsboard/server/common/data/rpc/Rpc.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/rpc/Rpc.java
@@ -44,6 +44,7 @@ public class Rpc extends BaseData<RpcId> implements HasTenantId {
     private RpcStatus status;
     @Schema(description = "Additional info used in the rule engine to process the updates to the RPC state.", accessMode = Schema.AccessMode.READ_ONLY)
     private JsonNode additionalInfo;
+    @Schema(description = "Transport request id used to correlate the device's response to this RPC.", accessMode = Schema.AccessMode.READ_ONLY)
     private Integer requestId;
 
     public Rpc() {

--- a/common/data/src/main/java/org/thingsboard/server/common/data/rpc/Rpc.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/rpc/Rpc.java
@@ -47,6 +47,8 @@ public class Rpc extends BaseData<RpcId> implements HasTenantId {
     private JsonNode additionalInfo;
     @JsonIgnore // internal transport correlation id used only for actor-side recovery; kept out of the public API and rule-engine payload
     private Integer requestId;
+    @JsonIgnore // internal flag mirrored from the request JSON; used only to let actor-side reload filter out terminal one-way DELIVERED rows
+    private Boolean oneway;
 
     public Rpc() {
         super();
@@ -66,6 +68,7 @@ public class Rpc extends BaseData<RpcId> implements HasTenantId {
         this.status = rpc.getStatus();
         this.additionalInfo = rpc.getAdditionalInfo();
         this.requestId = rpc.getRequestId();
+        this.oneway = rpc.getOneway();
     }
 
     @Schema(description = "JSON object with the rpc Id. Referencing non-existing rpc Id will cause error.")

--- a/common/data/src/main/java/org/thingsboard/server/common/data/rpc/Rpc.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/rpc/Rpc.java
@@ -45,9 +45,9 @@ public class Rpc extends BaseData<RpcId> implements HasTenantId {
     private RpcStatus status;
     @Schema(description = "Additional info used in the rule engine to process the updates to the RPC state.", accessMode = Schema.AccessMode.READ_ONLY)
     private JsonNode additionalInfo;
-    @JsonIgnore // internal transport correlation id used only for actor-side recovery; kept out of the public API and rule-engine payload
+    @JsonIgnore
     private Integer requestId;
-    @JsonIgnore // internal flag mirrored from the request JSON; used only to let actor-side reload filter out terminal one-way DELIVERED rows
+    @JsonIgnore
     private Boolean oneway;
 
     public Rpc() {

--- a/common/data/src/main/java/org/thingsboard/server/common/data/rpc/RpcStatus.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/rpc/RpcStatus.java
@@ -49,7 +49,7 @@ public enum RpcStatus {
             case DELIVERED -> EnumSet.of(QUEUED, SENT);
             case QUEUED -> EnumSet.of(SENT);                                     // retry re-queue
             case SUCCESSFUL, FAILED, EXPIRED -> EnumSet.of(QUEUED, SENT, DELIVERED); // in-flight only
-            default -> EnumSet.noneOf(RpcStatus.class);                          // TIMEOUT, DELETED: not via this path
+            case TIMEOUT, DELETED -> EnumSet.noneOf(RpcStatus.class);            // not written via the guarded UPDATE
         };
     }
 

--- a/common/data/src/main/java/org/thingsboard/server/common/data/rpc/RpcStatus.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/rpc/RpcStatus.java
@@ -39,17 +39,25 @@ public enum RpcStatus {
     }
 
     /**
-     * The set of CURRENT (persisted) statuses that a guarded status UPDATE to THIS (target) status is allowed to
-     * overwrite. No terminal status appears in any set, so terminals are immutable. The one-way vs two-way
-     * DELIVERED distinction is enforced separately in SQL, so it is intentionally absent here.
+     * The set of CURRENT (persisted) statuses that a guarded status UPDATE to THIS (target) status may overwrite.
+     * No terminal status appears in any set, so terminals are immutable. TIMEOUT is an in-flight peer of SENT
+     * (delivery ack timed out, retrying). The one-way and two-way machines differ in exactly one place: for a
+     * one-way RPC DELIVERED is a terminal success, so it is never an allowed predecessor of a terminal write.
      */
-    public Set<RpcStatus> getAllowedFromStatuses() {
+    public Set<RpcStatus> getAllowedFromStatuses(boolean oneway) {
         return switch (this) {
-            case SENT -> EnumSet.of(QUEUED);
-            case DELIVERED -> EnumSet.of(QUEUED, SENT);
-            case QUEUED -> EnumSet.of(SENT);                                     // retry re-queue
-            case SUCCESSFUL, FAILED, EXPIRED -> EnumSet.of(QUEUED, SENT, DELIVERED); // in-flight only
-            case TIMEOUT, DELETED -> EnumSet.noneOf(RpcStatus.class);            // not written via the guarded UPDATE
+            case SENT -> EnumSet.of(QUEUED, TIMEOUT);
+            case DELIVERED -> EnumSet.of(QUEUED, SENT, TIMEOUT);
+            case QUEUED -> EnumSet.of(SENT, TIMEOUT);                     // retry re-queue
+            case TIMEOUT -> EnumSet.of(SENT);                            // delivery ack timed out while SENT
+            // Terminals may overwrite any in-flight predecessor: async status writes and status-vs-response
+            // message reordering can leave the row at QUEUED when the outcome lands. One-way DELIVERED is a
+            // terminal success, so it is excluded for one-way; SUCCESSFUL is unreachable for one-way (no device
+            // response) but stays consistent with FAILED/EXPIRED.
+            case SUCCESSFUL, FAILED, EXPIRED -> oneway
+                    ? EnumSet.of(QUEUED, SENT, TIMEOUT)
+                    : EnumSet.of(QUEUED, SENT, DELIVERED, TIMEOUT);
+            case DELETED -> EnumSet.noneOf(RpcStatus.class);             // not written via the guarded UPDATE
         };
     }
 

--- a/common/data/src/main/java/org/thingsboard/server/common/data/rpc/RpcStatus.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/rpc/RpcStatus.java
@@ -17,6 +17,9 @@ package org.thingsboard.server.common.data.rpc;
 
 import lombok.Getter;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 public enum RpcStatus {
 
     QUEUED(true),
@@ -33,6 +36,21 @@ public enum RpcStatus {
 
     RpcStatus(boolean pushDeleteNotificationToCore) {
         this.pushDeleteNotificationToCore = pushDeleteNotificationToCore;
+    }
+
+    /**
+     * The set of CURRENT (persisted) statuses that a guarded status UPDATE to THIS (target) status is allowed to
+     * overwrite. No terminal status appears in any set, so terminals are immutable. The one-way vs two-way
+     * DELIVERED distinction is enforced separately in SQL, so it is intentionally absent here.
+     */
+    public Set<RpcStatus> getAllowedFromStatuses() {
+        return switch (this) {
+            case SENT -> EnumSet.of(QUEUED);
+            case DELIVERED -> EnumSet.of(QUEUED, SENT);
+            case QUEUED -> EnumSet.of(SENT);                                     // retry re-queue
+            case SUCCESSFUL, FAILED, EXPIRED -> EnumSet.of(QUEUED, SENT, DELIVERED); // in-flight only
+            default -> EnumSet.noneOf(RpcStatus.class);                          // TIMEOUT, DELETED: not via this path
+        };
     }
 
 }

--- a/common/data/src/test/java/org/thingsboard/server/common/data/rpc/RpcStatusTest.java
+++ b/common/data/src/test/java/org/thingsboard/server/common/data/rpc/RpcStatusTest.java
@@ -18,11 +18,17 @@ package org.thingsboard.server.common.data.rpc;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.thingsboard.server.common.data.rpc.RpcStatus.DELIVERED;
 import static org.thingsboard.server.common.data.rpc.RpcStatus.QUEUED;
 import static org.thingsboard.server.common.data.rpc.RpcStatus.SENT;
+import static org.thingsboard.server.common.data.rpc.RpcStatus.EXPIRED;
+import static org.thingsboard.server.common.data.rpc.RpcStatus.FAILED;
+import static org.thingsboard.server.common.data.rpc.RpcStatus.SUCCESSFUL;
+import static org.thingsboard.server.common.data.rpc.RpcStatus.DELETED;
+import static org.thingsboard.server.common.data.rpc.RpcStatus.TIMEOUT;
 
 class RpcStatusTest {
 
@@ -41,6 +47,29 @@ class RpcStatusTest {
             } else {
                 assertThat(status.isPushDeleteNotificationToCore()).isFalse();
             }
+        }
+    }
+
+    @Test
+    void allowedFromStatuses_matchesStateMachine() {
+        assertThat(SENT.getAllowedFromStatuses()).containsExactlyInAnyOrder(QUEUED);
+        assertThat(DELIVERED.getAllowedFromStatuses()).containsExactlyInAnyOrder(QUEUED, SENT);
+        assertThat(QUEUED.getAllowedFromStatuses()).containsExactlyInAnyOrder(SENT);
+        assertThat(SUCCESSFUL.getAllowedFromStatuses()).containsExactlyInAnyOrder(QUEUED, SENT, DELIVERED);
+        assertThat(FAILED.getAllowedFromStatuses()).containsExactlyInAnyOrder(QUEUED, SENT, DELIVERED);
+        assertThat(EXPIRED.getAllowedFromStatuses()).containsExactlyInAnyOrder(QUEUED, SENT, DELIVERED);
+        assertThat(TIMEOUT.getAllowedFromStatuses()).isEmpty();
+        assertThat(DELETED.getAllowedFromStatuses()).isEmpty();
+    }
+
+    @Test
+    void terminalStatusesNeverAppearAsAllowedFromSource() {
+        // A terminal status must never be overwritable by any transition -> it appears in no allowed-from set.
+        Set<RpcStatus> terminals = Set.of(SUCCESSFUL, FAILED, EXPIRED, DELETED);
+        for (RpcStatus target : RpcStatus.values()) {
+            assertThat(target.getAllowedFromStatuses())
+                    .as("target %s must not allow overwriting a terminal status", target)
+                    .doesNotContainAnyElementsOf(terminals);
         }
     }
 

--- a/common/data/src/test/java/org/thingsboard/server/common/data/rpc/RpcStatusTest.java
+++ b/common/data/src/test/java/org/thingsboard/server/common/data/rpc/RpcStatusTest.java
@@ -51,15 +51,25 @@ class RpcStatusTest {
     }
 
     @Test
-    void allowedFromStatuses_matchesStateMachine() {
-        assertThat(SENT.getAllowedFromStatuses()).containsExactlyInAnyOrder(QUEUED);
-        assertThat(DELIVERED.getAllowedFromStatuses()).containsExactlyInAnyOrder(QUEUED, SENT);
-        assertThat(QUEUED.getAllowedFromStatuses()).containsExactlyInAnyOrder(SENT);
-        assertThat(SUCCESSFUL.getAllowedFromStatuses()).containsExactlyInAnyOrder(QUEUED, SENT, DELIVERED);
-        assertThat(FAILED.getAllowedFromStatuses()).containsExactlyInAnyOrder(QUEUED, SENT, DELIVERED);
-        assertThat(EXPIRED.getAllowedFromStatuses()).containsExactlyInAnyOrder(QUEUED, SENT, DELIVERED);
-        assertThat(TIMEOUT.getAllowedFromStatuses()).isEmpty();
-        assertThat(DELETED.getAllowedFromStatuses()).isEmpty();
+    void allowedFromStatuses_twoWay() {
+        assertThat(SENT.getAllowedFromStatuses(false)).containsExactlyInAnyOrder(QUEUED, TIMEOUT);
+        assertThat(DELIVERED.getAllowedFromStatuses(false)).containsExactlyInAnyOrder(QUEUED, SENT, TIMEOUT);
+        assertThat(QUEUED.getAllowedFromStatuses(false)).containsExactlyInAnyOrder(SENT, TIMEOUT);
+        assertThat(TIMEOUT.getAllowedFromStatuses(false)).containsExactlyInAnyOrder(SENT);
+        assertThat(SUCCESSFUL.getAllowedFromStatuses(false)).containsExactlyInAnyOrder(QUEUED, SENT, DELIVERED, TIMEOUT);
+        assertThat(FAILED.getAllowedFromStatuses(false)).containsExactlyInAnyOrder(QUEUED, SENT, DELIVERED, TIMEOUT);
+        assertThat(EXPIRED.getAllowedFromStatuses(false)).containsExactlyInAnyOrder(QUEUED, SENT, DELIVERED, TIMEOUT);
+        assertThat(DELETED.getAllowedFromStatuses(false)).isEmpty();
+    }
+
+    @Test
+    void allowedFromStatuses_oneWayExcludesDeliveredForTerminals() {
+        assertThat(SUCCESSFUL.getAllowedFromStatuses(true)).containsExactlyInAnyOrder(QUEUED, SENT, TIMEOUT);
+        assertThat(FAILED.getAllowedFromStatuses(true)).containsExactlyInAnyOrder(QUEUED, SENT, TIMEOUT);
+        assertThat(EXPIRED.getAllowedFromStatuses(true)).containsExactlyInAnyOrder(QUEUED, SENT, TIMEOUT);
+        // non-terminal targets ignore oneway
+        assertThat(DELIVERED.getAllowedFromStatuses(true)).containsExactlyInAnyOrder(QUEUED, SENT, TIMEOUT);
+        assertThat(SENT.getAllowedFromStatuses(true)).containsExactlyInAnyOrder(QUEUED, TIMEOUT);
     }
 
     @Test
@@ -67,8 +77,11 @@ class RpcStatusTest {
         // A terminal status must never be overwritable by any transition -> it appears in no allowed-from set.
         Set<RpcStatus> terminals = Set.of(SUCCESSFUL, FAILED, EXPIRED, DELETED);
         for (RpcStatus target : RpcStatus.values()) {
-            assertThat(target.getAllowedFromStatuses())
-                    .as("target %s must not allow overwriting a terminal status", target)
+            assertThat(target.getAllowedFromStatuses(false))
+                    .as("target %s (two-way) must not allow overwriting a terminal status", target)
+                    .doesNotContainAnyElementsOf(terminals);
+            assertThat(target.getAllowedFromStatuses(true))
+                    .as("target %s (one-way) must not allow overwriting a terminal status", target)
                     .doesNotContainAnyElementsOf(terminals);
         }
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/model/ModelConstants.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/ModelConstants.java
@@ -586,6 +586,7 @@ public class ModelConstants {
     public static final String RPC_RESPONSE = "response";
     public static final String RPC_STATUS = "status";
     public static final String RPC_ADDITIONAL_INFO = ADDITIONAL_INFO_PROPERTY;
+    public static final String RPC_REQUEST_ID = "request_id";
 
     /**
      * Edge constants.

--- a/dao/src/main/java/org/thingsboard/server/dao/model/ModelConstants.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/ModelConstants.java
@@ -587,6 +587,7 @@ public class ModelConstants {
     public static final String RPC_STATUS = "status";
     public static final String RPC_ADDITIONAL_INFO = ADDITIONAL_INFO_PROPERTY;
     public static final String RPC_REQUEST_ID = "request_id";
+    public static final String RPC_ONEWAY = "oneway";
 
     /**
      * Edge constants.

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/RpcEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/RpcEntity.java
@@ -39,6 +39,7 @@ import static org.thingsboard.server.dao.model.ModelConstants.RPC_ADDITIONAL_INF
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_DEVICE_ID;
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_EXPIRATION_TIME;
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_REQUEST;
+import static org.thingsboard.server.dao.model.ModelConstants.RPC_REQUEST_ID;
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_RESPONSE;
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_STATUS;
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_TABLE_NAME;
@@ -75,6 +76,9 @@ public class RpcEntity extends BaseSqlEntity<Rpc> implements BaseEntity<Rpc> {
     @Column(name = RPC_ADDITIONAL_INFO)
     private JsonNode additionalInfo;
 
+    @Column(name = RPC_REQUEST_ID)
+    private Integer requestId;
+
     public RpcEntity() {
         super();
     }
@@ -89,6 +93,7 @@ public class RpcEntity extends BaseSqlEntity<Rpc> implements BaseEntity<Rpc> {
         this.response = rpc.getResponse();
         this.status = rpc.getStatus();
         this.additionalInfo = rpc.getAdditionalInfo();
+        this.requestId = rpc.getRequestId();
     }
 
     @Override
@@ -102,6 +107,7 @@ public class RpcEntity extends BaseSqlEntity<Rpc> implements BaseEntity<Rpc> {
         rpc.setResponse(response);
         rpc.setStatus(status);
         rpc.setAdditionalInfo(additionalInfo);
+        rpc.setRequestId(requestId);
         return rpc;
     }
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/RpcEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/RpcEntity.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_ADDITIONAL_INFO;
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_DEVICE_ID;
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_EXPIRATION_TIME;
+import static org.thingsboard.server.dao.model.ModelConstants.RPC_ONEWAY;
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_REQUEST;
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_REQUEST_ID;
 import static org.thingsboard.server.dao.model.ModelConstants.RPC_RESPONSE;
@@ -79,6 +80,9 @@ public class RpcEntity extends BaseSqlEntity<Rpc> implements BaseEntity<Rpc> {
     @Column(name = RPC_REQUEST_ID)
     private Integer requestId;
 
+    @Column(name = RPC_ONEWAY)
+    private Boolean oneway;
+
     public RpcEntity() {
         super();
     }
@@ -94,6 +98,7 @@ public class RpcEntity extends BaseSqlEntity<Rpc> implements BaseEntity<Rpc> {
         this.status = rpc.getStatus();
         this.additionalInfo = rpc.getAdditionalInfo();
         this.requestId = rpc.getRequestId();
+        this.oneway = rpc.getOneway();
     }
 
     @Override
@@ -108,6 +113,7 @@ public class RpcEntity extends BaseSqlEntity<Rpc> implements BaseEntity<Rpc> {
         rpc.setStatus(status);
         rpc.setAdditionalInfo(additionalInfo);
         rpc.setRequestId(requestId);
+        rpc.setOneway(oneway);
         return rpc;
     }
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/rpc/BaseRpcService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rpc/BaseRpcService.java
@@ -32,6 +32,7 @@ import org.thingsboard.server.common.data.rpc.Rpc;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 
+import java.util.Collection;
 import java.util.Optional;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -107,6 +108,14 @@ public class BaseRpcService implements RpcService {
         validateId(tenantId, id -> INCORRECT_TENANT_ID + id);
         validatePageLink(pageLink);
         return rpcDao.findAllByDeviceIdAndStatus(tenantId, deviceId, rpcStatus, pageLink);
+    }
+
+    @Override
+    public PageData<Rpc> findAllByDeviceIdAndStatusIn(TenantId tenantId, DeviceId deviceId, Collection<RpcStatus> statuses, PageLink pageLink) {
+        log.trace("Executing findAllByDeviceIdAndStatusIn, tenantId [{}], deviceId [{}], statuses [{}], pageLink [{}]", tenantId, deviceId, statuses, pageLink);
+        validateId(tenantId, id -> INCORRECT_TENANT_ID + id);
+        validatePageLink(pageLink);
+        return rpcDao.findAllByDeviceIdAndStatusIn(tenantId, deviceId, statuses, pageLink);
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/rpc/BaseRpcService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rpc/BaseRpcService.java
@@ -32,7 +32,6 @@ import org.thingsboard.server.common.data.rpc.Rpc;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 
-import java.util.Collection;
 import java.util.Optional;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -111,11 +110,11 @@ public class BaseRpcService implements RpcService {
     }
 
     @Override
-    public PageData<Rpc> findAllByDeviceIdAndStatusIn(TenantId tenantId, DeviceId deviceId, Collection<RpcStatus> statuses, PageLink pageLink) {
-        log.trace("Executing findAllByDeviceIdAndStatusIn, tenantId [{}], deviceId [{}], statuses [{}], pageLink [{}]", tenantId, deviceId, statuses, pageLink);
+    public PageData<Rpc> findInFlightForReload(TenantId tenantId, DeviceId deviceId, PageLink pageLink) {
+        log.trace("Executing findInFlightForReload, tenantId [{}], deviceId [{}], pageLink [{}]", tenantId, deviceId, pageLink);
         validateId(tenantId, id -> INCORRECT_TENANT_ID + id);
         validatePageLink(pageLink);
-        return rpcDao.findAllByDeviceIdAndStatusIn(tenantId, deviceId, statuses, pageLink);
+        return rpcDao.findInFlightForReload(tenantId, deviceId, pageLink);
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/rpc/RpcDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rpc/RpcDao.java
@@ -24,6 +24,8 @@ import org.thingsboard.server.common.data.rpc.Rpc;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.dao.Dao;
 
+import java.util.Collection;
+
 public interface RpcDao extends Dao<Rpc> {
 
     ListenableFuture<Boolean> updateAsync(Rpc rpc);
@@ -31,6 +33,8 @@ public interface RpcDao extends Dao<Rpc> {
     PageData<Rpc> findAllByDeviceId(TenantId tenantId, DeviceId deviceId, PageLink pageLink);
 
     PageData<Rpc> findAllByDeviceIdAndStatus(TenantId tenantId, DeviceId deviceId, RpcStatus rpcStatus, PageLink pageLink);
+
+    PageData<Rpc> findAllByDeviceIdAndStatusIn(TenantId tenantId, DeviceId deviceId, Collection<RpcStatus> statuses, PageLink pageLink);
 
     PageData<Rpc> findAllRpcByTenantId(TenantId tenantId, PageLink pageLink);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/rpc/RpcDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rpc/RpcDao.java
@@ -24,8 +24,6 @@ import org.thingsboard.server.common.data.rpc.Rpc;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.dao.Dao;
 
-import java.util.Collection;
-
 public interface RpcDao extends Dao<Rpc> {
 
     ListenableFuture<Boolean> updateAsync(Rpc rpc);
@@ -34,7 +32,7 @@ public interface RpcDao extends Dao<Rpc> {
 
     PageData<Rpc> findAllByDeviceIdAndStatus(TenantId tenantId, DeviceId deviceId, RpcStatus rpcStatus, PageLink pageLink);
 
-    PageData<Rpc> findAllByDeviceIdAndStatusIn(TenantId tenantId, DeviceId deviceId, Collection<RpcStatus> statuses, PageLink pageLink);
+    PageData<Rpc> findInFlightForReload(TenantId tenantId, DeviceId deviceId, PageLink pageLink);
 
     PageData<Rpc> findAllRpcByTenantId(TenantId tenantId, PageLink pageLink);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDao.java
@@ -42,6 +42,7 @@ import org.thingsboard.server.dao.sql.TbSqlBlockingQueueParams;
 import org.thingsboard.server.dao.sql.TbSqlBlockingQueueWrapper;
 import org.thingsboard.server.dao.util.SqlDao;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.UUID;
 import java.util.function.Function;
@@ -118,6 +119,11 @@ public class JpaRpcDao extends JpaAbstractDao<RpcEntity, Rpc> implements RpcDao,
     @Override
     public PageData<Rpc> findAllByDeviceIdAndStatus(TenantId tenantId, DeviceId deviceId, RpcStatus rpcStatus, PageLink pageLink) {
         return DaoUtil.toPageData(rpcRepository.findAllByTenantIdAndDeviceIdAndStatus(tenantId.getId(), deviceId.getId(), rpcStatus, DaoUtil.toPageable(pageLink)));
+    }
+
+    @Override
+    public PageData<Rpc> findAllByDeviceIdAndStatusIn(TenantId tenantId, DeviceId deviceId, Collection<RpcStatus> statuses, PageLink pageLink) {
+        return DaoUtil.toPageData(rpcRepository.findAllByTenantIdAndDeviceIdAndStatusIn(tenantId.getId(), deviceId.getId(), statuses, DaoUtil.toPageable(pageLink)));
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDao.java
@@ -42,7 +42,6 @@ import org.thingsboard.server.dao.sql.TbSqlBlockingQueueParams;
 import org.thingsboard.server.dao.sql.TbSqlBlockingQueueWrapper;
 import org.thingsboard.server.dao.util.SqlDao;
 
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.UUID;
 import java.util.function.Function;
@@ -122,8 +121,8 @@ public class JpaRpcDao extends JpaAbstractDao<RpcEntity, Rpc> implements RpcDao,
     }
 
     @Override
-    public PageData<Rpc> findAllByDeviceIdAndStatusIn(TenantId tenantId, DeviceId deviceId, Collection<RpcStatus> statuses, PageLink pageLink) {
-        return DaoUtil.toPageData(rpcRepository.findAllByTenantIdAndDeviceIdAndStatusIn(tenantId.getId(), deviceId.getId(), statuses, DaoUtil.toPageable(pageLink)));
+    public PageData<Rpc> findInFlightForReload(TenantId tenantId, DeviceId deviceId, PageLink pageLink) {
+        return DaoUtil.toPageData(rpcRepository.findInFlightForReload(tenantId.getId(), deviceId.getId(), DaoUtil.toPageable(pageLink)));
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcRepository.java
@@ -25,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.dao.model.sql.RpcEntity;
 
-import java.util.Collection;
 import java.util.UUID;
 
 public interface RpcRepository extends JpaRepository<RpcEntity, UUID> {
@@ -34,9 +33,14 @@ public interface RpcRepository extends JpaRepository<RpcEntity, UUID> {
 
     Page<RpcEntity> findAllByTenantIdAndDeviceIdAndStatus(UUID tenantId, UUID deviceId, RpcStatus status, Pageable pageable);
 
-    Page<RpcEntity> findAllByTenantIdAndDeviceIdAndStatusIn(UUID tenantId, UUID deviceId, Collection<RpcStatus> statuses, Pageable pageable);
-
     Page<RpcEntity> findAllByTenantId(UUID tenantId, Pageable pageable);
+
+    @Query(value = "SELECT * FROM rpc WHERE tenant_id = :tenantId AND device_id = :deviceId " +
+            "AND (status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false))",
+           countQuery = "SELECT count(*) FROM rpc WHERE tenant_id = :tenantId AND device_id = :deviceId " +
+            "AND (status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false))",
+           nativeQuery = true)
+    Page<RpcEntity> findInFlightForReload(@Param("tenantId") UUID tenantId, @Param("deviceId") UUID deviceId, Pageable pageable);
 
     @Transactional
     @Modifying

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcRepository.java
@@ -29,16 +29,18 @@ import java.util.UUID;
 
 public interface RpcRepository extends JpaRepository<RpcEntity, UUID> {
 
+    // Must stay identical to the idx_rpc_in_flight predicate (schema-entities-idx.sql / 4.3.1.4/schema_update.sql)
+    // so the planner can use that index.
+    String IN_FLIGHT_RELOAD_PREDICATE = "status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false)";
+
     Page<RpcEntity> findAllByTenantIdAndDeviceId(UUID tenantId, UUID deviceId, Pageable pageable);
 
     Page<RpcEntity> findAllByTenantIdAndDeviceIdAndStatus(UUID tenantId, UUID deviceId, RpcStatus status, Pageable pageable);
 
     Page<RpcEntity> findAllByTenantId(UUID tenantId, Pageable pageable);
 
-    @Query(value = "SELECT * FROM rpc WHERE tenant_id = :tenantId AND device_id = :deviceId " +
-            "AND (status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false))",
-           countQuery = "SELECT count(*) FROM rpc WHERE tenant_id = :tenantId AND device_id = :deviceId " +
-            "AND (status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false))",
+    @Query(value = "SELECT * FROM rpc WHERE tenant_id = :tenantId AND device_id = :deviceId AND (" + IN_FLIGHT_RELOAD_PREDICATE + ")",
+           countQuery = "SELECT count(*) FROM rpc WHERE tenant_id = :tenantId AND device_id = :deviceId AND (" + IN_FLIGHT_RELOAD_PREDICATE + ")",
            nativeQuery = true)
     Page<RpcEntity> findInFlightForReload(@Param("tenantId") UUID tenantId, @Param("deviceId") UUID deviceId, Pageable pageable);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcRepository.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.dao.model.sql.RpcEntity;
 
+import java.util.Collection;
 import java.util.UUID;
 
 public interface RpcRepository extends JpaRepository<RpcEntity, UUID> {
@@ -32,6 +33,8 @@ public interface RpcRepository extends JpaRepository<RpcEntity, UUID> {
     Page<RpcEntity> findAllByTenantIdAndDeviceId(UUID tenantId, UUID deviceId, Pageable pageable);
 
     Page<RpcEntity> findAllByTenantIdAndDeviceIdAndStatus(UUID tenantId, UUID deviceId, RpcStatus status, Pageable pageable);
+
+    Page<RpcEntity> findAllByTenantIdAndDeviceIdAndStatusIn(UUID tenantId, UUID deviceId, Collection<RpcStatus> statuses, Pageable pageable);
 
     Page<RpcEntity> findAllByTenantId(UUID tenantId, Pageable pageable);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcRepository.java
@@ -29,8 +29,6 @@ import java.util.UUID;
 
 public interface RpcRepository extends JpaRepository<RpcEntity, UUID> {
 
-    // Must stay identical to the idx_rpc_in_flight predicate (schema-entities-idx.sql / 4.3.1.4/schema_update.sql)
-    // so the planner can use that index.
     String IN_FLIGHT_RELOAD_PREDICATE = "status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false)";
 
     Page<RpcEntity> findAllByTenantIdAndDeviceId(UUID tenantId, UUID deviceId, Pageable pageable);

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcRepository.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 
 public interface RpcRepository extends JpaRepository<RpcEntity, UUID> {
 
-    String IN_FLIGHT_RELOAD_PREDICATE = "status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false)";
+    String IN_FLIGHT_RELOAD_PREDICATE = "status IN ('QUEUED','SENT','TIMEOUT') OR (status = 'DELIVERED' AND oneway = false)";
 
     Page<RpcEntity> findAllByTenantIdAndDeviceId(UUID tenantId, UUID deviceId, Pageable pageable);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
@@ -19,13 +19,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.stereotype.Repository;
 import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.dao.model.sql.RpcEntity;
 import org.thingsboard.server.dao.sqlts.insert.AbstractInsertRepository;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 @Repository
 public class RpcUpdateRepository extends AbstractInsertRepository {
@@ -33,6 +36,19 @@ public class RpcUpdateRepository extends AbstractInsertRepository {
     private static final String UPDATE =
             "UPDATE rpc SET status = ?, response = COALESCE(?, response) " +
             "WHERE id = ? AND status = ANY(?);";
+
+    // Allowed-from arrays are a pure function of (target status, oneway), so precompute them once instead of
+    // rebuilding an EnumSet + String[] for every row in every batch on the RPC status-write hot path.
+    private static final Map<RpcStatus, String[]> ALLOWED_FROM_TWO_WAY = precomputeAllowedFrom(false);
+    private static final Map<RpcStatus, String[]> ALLOWED_FROM_ONE_WAY = precomputeAllowedFrom(true);
+
+    private static Map<RpcStatus, String[]> precomputeAllowedFrom(boolean oneway) {
+        Map<RpcStatus, String[]> byStatus = new EnumMap<>(RpcStatus.class);
+        for (RpcStatus status : RpcStatus.values()) {
+            byStatus.put(status, status.getAllowedFromStatuses(oneway).stream().map(Enum::name).toArray(String[]::new));
+        }
+        return byStatus;
+    }
 
     List<Boolean> update(List<RpcEntity> updates) {
         return transactionTemplate.execute(status -> {
@@ -43,10 +59,7 @@ public class RpcUpdateRepository extends AbstractInsertRepository {
                     ps.setString(1, rpc.getStatus().name());
                     ps.setString(2, toJsonStr(rpc.getResponse()));
                     ps.setObject(3, rpc.getUuid());
-                    String[] allowedFrom = rpc.getStatus()
-                            .getAllowedFromStatuses(Boolean.TRUE.equals(rpc.getOneway()))
-                            .stream().map(Enum::name).toArray(String[]::new);
-                    ps.setArray(4, ps.getConnection().createArrayOf("varchar", allowedFrom));
+                    ps.setArray(4, ps.getConnection().createArrayOf("varchar", allowedFromArray(rpc)));
                 }
 
                 @Override
@@ -61,6 +74,11 @@ public class RpcUpdateRepository extends AbstractInsertRepository {
             }
             return persisted;
         });
+    }
+
+    private static String[] allowedFromArray(RpcEntity rpc) {
+        Map<RpcStatus, String[]> byStatus = Boolean.TRUE.equals(rpc.getOneway()) ? ALLOWED_FROM_ONE_WAY : ALLOWED_FROM_TWO_WAY;
+        return byStatus.get(rpc.getStatus());
     }
 
     private String toJsonStr(JsonNode node) {

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
@@ -32,7 +32,7 @@ public class RpcUpdateRepository extends AbstractInsertRepository {
 
     private static final String UPDATE =
             "UPDATE rpc SET status = ?, response = COALESCE(?, response) " +
-            "WHERE id = ? AND status = ANY(?) AND NOT (status = 'DELIVERED' AND oneway = TRUE);";
+            "WHERE id = ? AND status = ANY(?) AND NOT (status = 'DELIVERED' AND COALESCE(oneway, FALSE) = TRUE);";
 
     List<Boolean> update(List<RpcEntity> updates) {
         return transactionTemplate.execute(status -> {

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
@@ -32,7 +32,7 @@ public class RpcUpdateRepository extends AbstractInsertRepository {
 
     private static final String UPDATE =
             "UPDATE rpc SET status = ?, response = COALESCE(?, response) " +
-            "WHERE id = ? AND status = ANY(?) AND NOT (status = 'DELIVERED' AND COALESCE(oneway, FALSE) = TRUE);";
+            "WHERE id = ? AND status = ANY(?);";
 
     List<Boolean> update(List<RpcEntity> updates) {
         return transactionTemplate.execute(status -> {
@@ -43,8 +43,9 @@ public class RpcUpdateRepository extends AbstractInsertRepository {
                     ps.setString(1, rpc.getStatus().name());
                     ps.setString(2, toJsonStr(rpc.getResponse()));
                     ps.setObject(3, rpc.getUuid());
-                    String[] allowedFrom = rpc.getStatus().getAllowedFromStatuses().stream()
-                            .map(Enum::name).toArray(String[]::new);
+                    String[] allowedFrom = rpc.getStatus()
+                            .getAllowedFromStatuses(Boolean.TRUE.equals(rpc.getOneway()))
+                            .stream().map(Enum::name).toArray(String[]::new);
                     ps.setArray(4, ps.getConnection().createArrayOf("varchar", allowedFrom));
                 }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
@@ -31,7 +31,8 @@ import java.util.List;
 public class RpcUpdateRepository extends AbstractInsertRepository {
 
     private static final String UPDATE =
-            "UPDATE rpc SET status = ?, response = COALESCE(?, response) WHERE id = ?;";
+            "UPDATE rpc SET status = ?, response = COALESCE(?, response) " +
+            "WHERE id = ? AND status = ANY(?) AND NOT (status = 'DELIVERED' AND oneway = TRUE);";
 
     List<Boolean> update(List<RpcEntity> updates) {
         return transactionTemplate.execute(status -> {
@@ -42,6 +43,9 @@ public class RpcUpdateRepository extends AbstractInsertRepository {
                     ps.setString(1, rpc.getStatus().name());
                     ps.setString(2, toJsonStr(rpc.getResponse()));
                     ps.setObject(3, rpc.getUuid());
+                    String[] allowedFrom = rpc.getStatus().getAllowedFromStatuses().stream()
+                            .map(Enum::name).toArray(String[]::new);
+                    ps.setArray(4, ps.getConnection().createArrayOf("varchar", allowedFrom));
                 }
 
                 @Override

--- a/dao/src/main/resources/sql/schema-entities-idx.sql
+++ b/dao/src/main/resources/sql/schema-entities-idx.sql
@@ -73,7 +73,6 @@ CREATE INDEX IF NOT EXISTS idx_edge_event_id ON edge_event(id);
 
 CREATE INDEX IF NOT EXISTS idx_rpc_tenant_id_device_id ON rpc(tenant_id, device_id);
 
--- keep in sync with application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql (idx_rpc_in_flight)
 CREATE INDEX IF NOT EXISTS idx_rpc_in_flight ON rpc (tenant_id, device_id)
     WHERE status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false);
 

--- a/dao/src/main/resources/sql/schema-entities-idx.sql
+++ b/dao/src/main/resources/sql/schema-entities-idx.sql
@@ -73,6 +73,9 @@ CREATE INDEX IF NOT EXISTS idx_edge_event_id ON edge_event(id);
 
 CREATE INDEX IF NOT EXISTS idx_rpc_tenant_id_device_id ON rpc(tenant_id, device_id);
 
+CREATE INDEX IF NOT EXISTS idx_rpc_in_flight ON rpc (tenant_id, device_id)
+    WHERE status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false);
+
 CREATE INDEX IF NOT EXISTS idx_rule_node_external_id ON rule_node(rule_chain_id, external_id);
 
 CREATE INDEX IF NOT EXISTS idx_rule_node_type_id_configuration_version ON rule_node(type, id, configuration_version);

--- a/dao/src/main/resources/sql/schema-entities-idx.sql
+++ b/dao/src/main/resources/sql/schema-entities-idx.sql
@@ -74,7 +74,7 @@ CREATE INDEX IF NOT EXISTS idx_edge_event_id ON edge_event(id);
 CREATE INDEX IF NOT EXISTS idx_rpc_tenant_id_device_id ON rpc(tenant_id, device_id);
 
 CREATE INDEX IF NOT EXISTS idx_rpc_in_flight ON rpc (tenant_id, device_id)
-    WHERE status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false);
+    WHERE status IN ('QUEUED','SENT','TIMEOUT') OR (status = 'DELIVERED' AND oneway = false);
 
 CREATE INDEX IF NOT EXISTS idx_rule_node_external_id ON rule_node(rule_chain_id, external_id);
 

--- a/dao/src/main/resources/sql/schema-entities-idx.sql
+++ b/dao/src/main/resources/sql/schema-entities-idx.sql
@@ -73,6 +73,7 @@ CREATE INDEX IF NOT EXISTS idx_edge_event_id ON edge_event(id);
 
 CREATE INDEX IF NOT EXISTS idx_rpc_tenant_id_device_id ON rpc(tenant_id, device_id);
 
+-- keep in sync with application/src/main/data/upgrade/lts/4.3.1.4/schema_update.sql (idx_rpc_in_flight)
 CREATE INDEX IF NOT EXISTS idx_rpc_in_flight ON rpc (tenant_id, device_id)
     WHERE status IN ('QUEUED','SENT') OR (status = 'DELIVERED' AND oneway = false);
 

--- a/dao/src/main/resources/sql/schema-entities.sql
+++ b/dao/src/main/resources/sql/schema-entities.sql
@@ -782,7 +782,8 @@ CREATE TABLE IF NOT EXISTS rpc (
     request varchar(10000000) NOT NULL,
     response varchar(10000000),
     additional_info varchar(10000000),
-    status varchar(255) NOT NULL
+    status varchar(255) NOT NULL,
+    request_id integer
 );
 
 CREATE OR REPLACE FUNCTION to_uuid(IN entity_id varchar, OUT uuid_id uuid) AS

--- a/dao/src/main/resources/sql/schema-entities.sql
+++ b/dao/src/main/resources/sql/schema-entities.sql
@@ -783,7 +783,8 @@ CREATE TABLE IF NOT EXISTS rpc (
     response varchar(10000000),
     additional_info varchar(10000000),
     status varchar(255) NOT NULL,
-    request_id integer
+    request_id integer,
+    oneway boolean
 );
 
 CREATE OR REPLACE FUNCTION to_uuid(IN entity_id varchar, OUT uuid_id uuid) AS

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -18,6 +18,7 @@ package org.thingsboard.server.dao.sql.rpc;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.RpcId;
@@ -29,6 +30,7 @@ import org.thingsboard.server.dao.AbstractJpaDaoTest;
 import org.thingsboard.server.dao.model.sql.RpcEntity;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -41,6 +43,31 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
 
     @Autowired
     RpcUpdateRepository rpcUpdateRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    // Mirrors org.thingsboard.server.service.install.lts.V4_3_1_4Migration.CLEANUP_BATCH_SQL exactly: this test
+    // documents (and pins) the migration's WHERE clause against a real Postgres instance, including the
+    // request::jsonb ->> 'oneway' extraction, without the dao module depending on the application module.
+    private static final String LEGACY_CLEANUP_BATCH_SQL = """
+            WITH w AS (
+              SELECT id FROM rpc WHERE id > ? ORDER BY id LIMIT ?
+            ), u AS (
+              UPDATE rpc SET status = 'EXPIRED', response = ?
+              FROM w WHERE rpc.id = w.id
+                AND rpc.request_id IS NULL
+                AND rpc.expiration_time < ?
+                AND (rpc.status = 'SENT' OR (rpc.status = 'DELIVERED' AND (rpc.request::jsonb ->> 'oneway') = 'false'))
+              RETURNING 1
+            )
+            SELECT (SELECT count(*) FROM u) AS updated_count,
+                   (SELECT id FROM w ORDER BY id DESC LIMIT 1) AS last_id
+            """;
+
+    private static final String LEGACY_CLOSE_RESPONSE = "{\"error\":\"This RPC was no longer tracked by the platform "
+            + "after a restart and could not reach a terminal state on its own. It was left stuck in a "
+            + "non-terminal state (SENT or DELIVERED) and has now been closed automatically.\"}";
 
     @Test
     public void deleteOutdated() {
@@ -212,6 +239,48 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
                 .getData().stream().map(Rpc::getUuidId).toList();
 
         assertThat(got).containsExactlyInAnyOrder(q, s, twoWayDel);
+    }
+
+    @Test
+    public void legacyBacklogCleanupClosesOnlyStuckRows() {
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        long now = System.currentTimeMillis();
+        long past = now - 60_000;
+        long future = now + 60_000;
+
+        // Legacy (request_id IS NULL) rows the cleanup MUST close:
+        UUID twoWayDeliveredPastExpiry = saveLegacy(deviceId, RpcStatus.DELIVERED, false, past, null);
+        UUID sentPastExpiry = saveLegacy(deviceId, RpcStatus.SENT, true, past, null);
+        // Rows the cleanup MUST leave untouched:
+        UUID oneWayDeliveredPastExpiry = saveLegacy(deviceId, RpcStatus.DELIVERED, true, past, null); // terminal success
+        UUID twoWayDeliveredFutureExpiry = saveLegacy(deviceId, RpcStatus.DELIVERED, false, future, null); // not expired yet
+        UUID twoWayDeliveredWithRequestId = saveLegacy(deviceId, RpcStatus.DELIVERED, false, past, 7); // tracked, not legacy
+        UUID queuedPastExpiry = saveLegacy(deviceId, RpcStatus.QUEUED, false, past, null); // never sent
+
+        Map<String, Object> result = jdbcTemplate.queryForMap(LEGACY_CLEANUP_BATCH_SQL,
+                new UUID(0L, 0L), 10_000, LEGACY_CLOSE_RESPONSE, now);
+        assertThat(((Number) result.get("updated_count")).longValue()).isEqualTo(2);
+
+        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, twoWayDeliveredPastExpiry).getStatus()).isEqualTo(RpcStatus.EXPIRED);
+        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, sentPastExpiry).getStatus()).isEqualTo(RpcStatus.EXPIRED);
+
+        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, oneWayDeliveredPastExpiry).getStatus()).isEqualTo(RpcStatus.DELIVERED);
+        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, twoWayDeliveredFutureExpiry).getStatus()).isEqualTo(RpcStatus.DELIVERED);
+        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, twoWayDeliveredWithRequestId).getStatus()).isEqualTo(RpcStatus.DELIVERED);
+        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, queuedPastExpiry).getStatus()).isEqualTo(RpcStatus.QUEUED);
+    }
+
+    // Seeds a legacy row (bypassing the entity/JPA layer to write raw request JSON) exactly as a pre-request_id
+    // server version would have left it: request_id NULL, request JSON carrying the oneway flag the cleanup's
+    // WHERE extracts via request::jsonb ->> 'oneway'.
+    private UUID saveLegacy(DeviceId deviceId, RpcStatus status, boolean oneway, long expirationTime, Integer requestId) {
+        UUID id = UUID.randomUUID();
+        String request = "{\"oneway\":" + oneway + ",\"method\":\"x\"}";
+        jdbcTemplate.update("INSERT INTO rpc (id, created_time, tenant_id, device_id, expiration_time, request, " +
+                        "response, status, request_id, oneway) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)",
+                id, System.currentTimeMillis(), TenantId.SYS_TENANT_ID.getId(), deviceId.getId(), expirationTime,
+                request, status.name(), requestId, oneway);
+        return id;
     }
 
     private UUID saveRpc(DeviceId deviceId, RpcStatus status, boolean oneway) {

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -200,19 +200,28 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
     }
 
     @Test
-    public void findAllByDeviceIdAndStatusInReturnsOnlyMatchingStatuses() {
+    public void findInFlightForReloadExcludesOneWayDeliveredAndTerminal() {
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(UUID.randomUUID(), deviceId, RpcStatus.QUEUED, null));
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(UUID.randomUUID(), deviceId, RpcStatus.SENT, null));
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(UUID.randomUUID(), deviceId, RpcStatus.DELIVERED, null));
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(UUID.randomUUID(), deviceId, RpcStatus.SUCCESSFUL, null));
+        UUID q = saveRpc(deviceId, RpcStatus.QUEUED, false);
+        UUID s = saveRpc(deviceId, RpcStatus.SENT, true);          // one-way SENT still reloaded (retry)
+        UUID twoWayDel = saveRpc(deviceId, RpcStatus.DELIVERED, false);
+        saveRpc(deviceId, RpcStatus.DELIVERED, true);              // one-way DELIVERED -> excluded
+        saveRpc(deviceId, RpcStatus.SUCCESSFUL, false);            // terminal -> excluded
 
-        List<Rpc> inFlight = rpcDao.findAllByDeviceIdAndStatusIn(TenantId.SYS_TENANT_ID, deviceId,
-                List.of(RpcStatus.QUEUED, RpcStatus.SENT, RpcStatus.DELIVERED), new PageLink(100)).getData();
+        List<UUID> got = rpcDao.findInFlightForReload(TenantId.SYS_TENANT_ID, deviceId, new PageLink(100))
+                .getData().stream().map(Rpc::getUuidId).toList();
 
-        // the terminal SUCCESSFUL row is excluded; only the three in-flight statuses come back:
-        assertThat(inFlight).extracting(Rpc::getStatus)
-                .containsExactlyInAnyOrder(RpcStatus.QUEUED, RpcStatus.SENT, RpcStatus.DELIVERED);
+        assertThat(got).containsExactlyInAnyOrder(q, s, twoWayDel);
+    }
+
+    private UUID saveRpc(DeviceId deviceId, RpcStatus status, boolean oneway) {
+        UUID id = UUID.randomUUID();
+        Rpc toSave = rpc(id, deviceId, status, null);
+        toSave.setOneway(oneway);
+        toSave.setRequestId(null);
+        toSave.setExpirationTime(System.currentTimeMillis() + 60_000);
+        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, toSave);
+        return id;
     }
 
     private Rpc rpc(UUID id, DeviceId deviceId, RpcStatus status, JsonNode response) {

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -16,8 +16,10 @@
 package org.thingsboard.server.dao.sql.rpc;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.RpcId;
@@ -41,6 +43,19 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
 
     @Autowired
     RpcUpdateRepository rpcUpdateRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    private UUID rawSeededId;
+
+    @After
+    public void cleanupRawSeededRow() {
+        if (rawSeededId != null) {
+            jdbcTemplate.update("DELETE FROM rpc WHERE id = ?", rawSeededId);
+            rawSeededId = null;
+        }
+    }
 
     @Test
     public void deleteOutdated() {
@@ -268,6 +283,25 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
                 .getData().stream().map(Rpc::getUuidId).toList();
 
         assertThat(got).containsExactlyInAnyOrder(q, s, twoWayDel);
+    }
+
+    @Test
+    public void guardAllowsSuccessfulOnDeliveredRowWithNullOneway() throws Exception {
+        UUID id = UUID.randomUUID();
+        rawSeededId = id;
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        // Legacy row: oneway column NULL (pre-4.3.1.4). Raw insert because the entity writes a primitive boolean.
+        jdbcTemplate.update("INSERT INTO rpc (id, created_time, tenant_id, device_id, expiration_time, request, " +
+                        "response, status, request_id, oneway) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, NULL)",
+                id, System.currentTimeMillis(), TenantId.SYS_TENANT_ID.getId(), deviceId.getId(),
+                System.currentTimeMillis() + 60_000, "{\"method\":\"x\"}", "DELIVERED", 1);
+
+        // NULL oneway must be treated as two-way (not terminal): a real response may complete it.
+        assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.SUCCESSFUL, JacksonUtil.toJsonNode("{\"ok\":true}")))
+                .get(5, TimeUnit.SECONDS)).isTrue();
+        Rpc stored = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
+        assertThat(stored.getStatus()).isEqualTo(RpcStatus.SUCCESSFUL);
+        assertThat(stored.getResponse()).isEqualTo(JacksonUtil.toJsonNode("{\"ok\":true}"));
     }
 
     private UUID saveRpc(DeviceId deviceId, RpcStatus status, boolean oneway) {

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -18,7 +18,6 @@ package org.thingsboard.server.dao.sql.rpc;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.RpcId;
@@ -30,7 +29,6 @@ import org.thingsboard.server.dao.AbstractJpaDaoTest;
 import org.thingsboard.server.dao.model.sql.RpcEntity;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -43,31 +41,6 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
 
     @Autowired
     RpcUpdateRepository rpcUpdateRepository;
-
-    @Autowired
-    JdbcTemplate jdbcTemplate;
-
-    // Mirrors org.thingsboard.server.service.install.lts.V4_3_1_4Migration.CLEANUP_BATCH_SQL exactly: this test
-    // documents (and pins) the migration's WHERE clause against a real Postgres instance, including the
-    // request::jsonb ->> 'oneway' extraction, without the dao module depending on the application module.
-    private static final String LEGACY_CLEANUP_BATCH_SQL = """
-            WITH w AS (
-              SELECT id FROM rpc WHERE id > ? ORDER BY id LIMIT ?
-            ), u AS (
-              UPDATE rpc SET status = 'EXPIRED', response = ?
-              FROM w WHERE rpc.id = w.id
-                AND rpc.request_id IS NULL
-                AND rpc.expiration_time < ?
-                AND (rpc.status = 'SENT' OR (rpc.status = 'DELIVERED' AND (rpc.request::jsonb ->> 'oneway') = 'false'))
-              RETURNING 1
-            )
-            SELECT (SELECT count(*) FROM u) AS updated_count,
-                   (SELECT id FROM w ORDER BY id DESC LIMIT 1) AS last_id
-            """;
-
-    private static final String LEGACY_CLOSE_RESPONSE = "{\"error\":\"This RPC was no longer tracked by the platform "
-            + "after a restart and could not reach a terminal state on its own. It was left stuck in a "
-            + "non-terminal state (SENT or DELIVERED) and has now been closed automatically.\"}";
 
     @Test
     public void deleteOutdated() {
@@ -239,48 +212,6 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
                 .getData().stream().map(Rpc::getUuidId).toList();
 
         assertThat(got).containsExactlyInAnyOrder(q, s, twoWayDel);
-    }
-
-    @Test
-    public void legacyBacklogCleanupClosesOnlyStuckRows() {
-        DeviceId deviceId = new DeviceId(UUID.randomUUID());
-        long now = System.currentTimeMillis();
-        long past = now - 60_000;
-        long future = now + 60_000;
-
-        // Legacy (request_id IS NULL) rows the cleanup MUST close:
-        UUID twoWayDeliveredPastExpiry = saveLegacy(deviceId, RpcStatus.DELIVERED, false, past, null);
-        UUID sentPastExpiry = saveLegacy(deviceId, RpcStatus.SENT, true, past, null);
-        // Rows the cleanup MUST leave untouched:
-        UUID oneWayDeliveredPastExpiry = saveLegacy(deviceId, RpcStatus.DELIVERED, true, past, null); // terminal success
-        UUID twoWayDeliveredFutureExpiry = saveLegacy(deviceId, RpcStatus.DELIVERED, false, future, null); // not expired yet
-        UUID twoWayDeliveredWithRequestId = saveLegacy(deviceId, RpcStatus.DELIVERED, false, past, 7); // tracked, not legacy
-        UUID queuedPastExpiry = saveLegacy(deviceId, RpcStatus.QUEUED, false, past, null); // never sent
-
-        Map<String, Object> result = jdbcTemplate.queryForMap(LEGACY_CLEANUP_BATCH_SQL,
-                new UUID(0L, 0L), 10_000, LEGACY_CLOSE_RESPONSE, now);
-        assertThat(((Number) result.get("updated_count")).longValue()).isEqualTo(2);
-
-        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, twoWayDeliveredPastExpiry).getStatus()).isEqualTo(RpcStatus.EXPIRED);
-        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, sentPastExpiry).getStatus()).isEqualTo(RpcStatus.EXPIRED);
-
-        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, oneWayDeliveredPastExpiry).getStatus()).isEqualTo(RpcStatus.DELIVERED);
-        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, twoWayDeliveredFutureExpiry).getStatus()).isEqualTo(RpcStatus.DELIVERED);
-        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, twoWayDeliveredWithRequestId).getStatus()).isEqualTo(RpcStatus.DELIVERED);
-        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, queuedPastExpiry).getStatus()).isEqualTo(RpcStatus.QUEUED);
-    }
-
-    // Seeds a legacy row (bypassing the entity/JPA layer to write raw request JSON) exactly as a pre-request_id
-    // server version would have left it: request_id NULL, request JSON carrying the oneway flag the cleanup's
-    // WHERE extracts via request::jsonb ->> 'oneway'.
-    private UUID saveLegacy(DeviceId deviceId, RpcStatus status, boolean oneway, long expirationTime, Integer requestId) {
-        UUID id = UUID.randomUUID();
-        String request = "{\"oneway\":" + oneway + ",\"method\":\"x\"}";
-        jdbcTemplate.update("INSERT INTO rpc (id, created_time, tenant_id, device_id, expiration_time, request, " +
-                        "response, status, request_id, oneway) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)",
-                id, System.currentTimeMillis(), TenantId.SYS_TENANT_ID.getId(), deviceId.getId(), expirationTime,
-                request, status.name(), requestId, oneway);
-        return id;
     }
 
     private UUID saveRpc(DeviceId deviceId, RpcStatus status, boolean oneway) {

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -185,8 +185,11 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         created.setOneway(true);
         rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, created);
 
-        // The one-way DELIVERED clause protects it (guard reads oneway from the existing row).
-        assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.EXPIRED, null)).get(5, TimeUnit.SECONDS)).isFalse();
+        // One-way DELIVERED is terminal. A one-way write carries oneway=true (as the actor sets from the request),
+        // so its allowed-from set excludes DELIVERED and the guard blocks the overwrite.
+        Rpc staleExpired = rpc(id, deviceId, RpcStatus.EXPIRED, null);
+        staleExpired.setOneway(true);
+        assertThat(rpcDao.updateAsync(staleExpired).get(5, TimeUnit.SECONDS)).isFalse();
         assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, id).getStatus()).isEqualTo(RpcStatus.DELIVERED);
     }
 
@@ -199,7 +202,9 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, created);
 
         // Two-way DELIVERED is in-flight (awaiting response), so a genuine timeout may expire it.
-        assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.EXPIRED, null)).get(5, TimeUnit.SECONDS)).isTrue();
+        Rpc expired = rpc(id, deviceId, RpcStatus.EXPIRED, null);
+        expired.setOneway(false);
+        assertThat(rpcDao.updateAsync(expired).get(5, TimeUnit.SECONDS)).isTrue();
         assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, id).getStatus()).isEqualTo(RpcStatus.EXPIRED);
     }
 
@@ -275,6 +280,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
         UUID q = saveRpc(deviceId, RpcStatus.QUEUED, false);
         UUID s = saveRpc(deviceId, RpcStatus.SENT, true);          // one-way SENT still reloaded (retry)
+        UUID t = saveRpc(deviceId, RpcStatus.TIMEOUT, false);      // delivery ack timed out -> in-flight, reloaded
         UUID twoWayDel = saveRpc(deviceId, RpcStatus.DELIVERED, false);
         saveRpc(deviceId, RpcStatus.DELIVERED, true);              // one-way DELIVERED -> excluded
         saveRpc(deviceId, RpcStatus.SUCCESSFUL, false);            // terminal -> excluded
@@ -282,7 +288,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         List<UUID> got = rpcDao.findInFlightForReload(TenantId.SYS_TENANT_ID, deviceId, new PageLink(100))
                 .getData().stream().map(Rpc::getUuidId).toList();
 
-        assertThat(got).containsExactlyInAnyOrder(q, s, twoWayDel);
+        assertThat(got).containsExactlyInAnyOrder(q, s, t, twoWayDel);
     }
 
     @Test

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -191,6 +191,15 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
     }
 
     @Test
+    public void onewayRoundTripsThroughSaveAndLoad() {
+        UUID id = UUID.randomUUID();
+        Rpc toSave = rpc(id, new DeviceId(UUID.randomUUID()), RpcStatus.SENT, null);
+        toSave.setOneway(true);
+        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, toSave);
+        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, id).getOneway()).isTrue();
+    }
+
+    @Test
     public void findAllByDeviceIdAndStatusInReturnsOnlyMatchingStatuses() {
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
         rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(UUID.randomUUID(), deviceId, RpcStatus.QUEUED, null));

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -177,6 +177,18 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, id)).isNull();
     }
 
+    @Test
+    public void requestIdRoundTripsThroughSaveAndLoad() {
+        UUID id = UUID.randomUUID();
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        Rpc toSave = rpc(id, deviceId, RpcStatus.SENT, null);
+        toSave.setRequestId(42);
+        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, toSave);
+
+        Rpc loaded = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
+        assertThat(loaded.getRequestId()).isEqualTo(42);
+    }
+
     private Rpc rpc(UUID id, DeviceId deviceId, RpcStatus status, JsonNode response) {
         Rpc rpc = new Rpc(new RpcId(id));
         rpc.setCreatedTime(System.currentTimeMillis());

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -102,7 +102,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         // same partition in submission order. No queue timing involved.
         //   index 0: update A (SUCCESSFUL, {ok:true}) -> UPDATE hits the existing row  -> true
         //   index 1: update B (SUCCESSFUL, {x:1})     -> UPDATE for a missing row      -> false
-        //   index 2: update A (EXPIRED, null response) -> UPDATE hits A, keeps response -> true
+        //   index 2: update A (EXPIRED) -> guard blocks overwrite of terminal SUCCESSFUL -> false
         List<RpcEntity> batch = List.of(
                 new RpcEntity(rpc(idA, deviceId, RpcStatus.SUCCESSFUL, JacksonUtil.toJsonNode("{\"ok\":true}"))),
                 new RpcEntity(rpc(idB, deviceId, RpcStatus.SUCCESSFUL, JacksonUtil.toJsonNode("{\"x\":1}"))),
@@ -110,13 +110,16 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
 
         List<Boolean> persisted = rpcUpdateRepository.update(batch);
 
-        // Booleans are aligned positionally to submission order.
-        assertThat(persisted).containsExactly(true, false, true);
+        // Booleans align positionally to submission order:
+        //   index 0: A QUEUED -> SUCCESSFUL      -> allowed          -> true
+        //   index 1: B (missing row)             -> no match         -> false
+        //   index 2: A SUCCESSFUL -> EXPIRED     -> guard blocks it  -> false  (terminal is immutable)
+        assertThat(persisted).containsExactly(true, false, false);
 
-        // Updates apply in order, so A ends EXPIRED, and the null-response update kept the stored response.
+        // A stays SUCCESSFUL with its response: the in-batch EXPIRED was rejected by the guard.
         Rpc storedA = rpcDao.findById(TenantId.SYS_TENANT_ID, idA);
         assertThat(storedA).isNotNull();
-        assertThat(storedA.getStatus()).isEqualTo(RpcStatus.EXPIRED);
+        assertThat(storedA.getStatus()).isEqualTo(RpcStatus.SUCCESSFUL);
         assertThat(storedA.getResponse()).isEqualTo(JacksonUtil.toJsonNode("{\"ok\":true}"));
         // ...and the update for a never-created row neither persisted nor resurrected it.
         assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, idB)).isNull();
@@ -141,22 +144,75 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
     }
 
     @Test
-    public void saveAsyncNullResponseUpdateKeepsStoredResponse() throws Exception {
+    public void guardBlocksExpiredOverwritingSuccessful() throws Exception {
         UUID id = UUID.randomUUID();
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
 
         rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(id, deviceId, RpcStatus.QUEUED, null));
 
-        // A successful response is stored.
-        rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.SUCCESSFUL, JacksonUtil.toJsonNode("{\"ok\":true}")))
-                .get(5, TimeUnit.SECONDS);
+        // A real device response reaches SUCCESSFUL with a response body.
+        assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.SUCCESSFUL, JacksonUtil.toJsonNode("{\"ok\":true}")))
+                .get(5, TimeUnit.SECONDS)).isTrue();
 
-        // A later status update carries no response - it must NOT clobber the stored one.
-        rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.EXPIRED, null)).get(5, TimeUnit.SECONDS);
+        // A stale EXPIRED (e.g. from a migrated actor's timeout) must NOT overwrite it: future resolves false.
+        assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.EXPIRED, null)).get(5, TimeUnit.SECONDS)).isFalse();
 
         Rpc stored = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
-        assertThat(stored.getStatus()).isEqualTo(RpcStatus.EXPIRED);
+        assertThat(stored.getStatus()).isEqualTo(RpcStatus.SUCCESSFUL);
         assertThat(stored.getResponse()).isEqualTo(JacksonUtil.toJsonNode("{\"ok\":true}"));
+    }
+
+    @Test
+    public void guardBlocksExpiredOverwritingOneWayDelivered() throws Exception {
+        UUID id = UUID.randomUUID();
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        Rpc created = rpc(id, deviceId, RpcStatus.DELIVERED, null);
+        created.setOneway(true);
+        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, created);
+
+        // The one-way DELIVERED clause protects it (guard reads oneway from the existing row).
+        assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.EXPIRED, null)).get(5, TimeUnit.SECONDS)).isFalse();
+        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, id).getStatus()).isEqualTo(RpcStatus.DELIVERED);
+    }
+
+    @Test
+    public void guardAllowsExpiredOverwritingTwoWayDelivered() throws Exception {
+        UUID id = UUID.randomUUID();
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        Rpc created = rpc(id, deviceId, RpcStatus.DELIVERED, null);
+        created.setOneway(false);
+        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, created);
+
+        // Two-way DELIVERED is in-flight (awaiting response), so a genuine timeout may expire it.
+        assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.EXPIRED, null)).get(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, id).getStatus()).isEqualTo(RpcStatus.EXPIRED);
+    }
+
+    @Test
+    public void guardAllowsSuccessfulFromSent() throws Exception {
+        UUID id = UUID.randomUUID();
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(id, deviceId, RpcStatus.SENT, null));
+
+        // Response for an as-yet-undelivered RPC (no PUBACK) lands while status is still SENT.
+        assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.SUCCESSFUL, JacksonUtil.toJsonNode("{\"v\":1}")))
+                .get(5, TimeUnit.SECONDS)).isTrue();
+        Rpc stored = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
+        assertThat(stored.getStatus()).isEqualTo(RpcStatus.SUCCESSFUL);
+        assertThat(stored.getResponse()).isEqualTo(JacksonUtil.toJsonNode("{\"v\":1}"));
+    }
+
+    @Test
+    public void guardBlocksSentDowngradingDelivered() throws Exception {
+        UUID id = UUID.randomUUID();
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        Rpc created = rpc(id, deviceId, RpcStatus.DELIVERED, null);
+        created.setOneway(false);
+        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, created);
+
+        // A stale/duplicate SENT must not roll DELIVERED backwards.
+        assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.SENT, null)).get(5, TimeUnit.SECONDS)).isFalse();
+        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, id).getStatus()).isEqualTo(RpcStatus.DELIVERED);
     }
 
     @Test

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -22,6 +22,7 @@ import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.RpcId;
 import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.page.PageLink;
 import org.thingsboard.server.common.data.rpc.Rpc;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.dao.AbstractJpaDaoTest;
@@ -187,6 +188,22 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
 
         Rpc loaded = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
         assertThat(loaded.getRequestId()).isEqualTo(42);
+    }
+
+    @Test
+    public void findAllByDeviceIdAndStatusInReturnsOnlyMatchingStatuses() {
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(UUID.randomUUID(), deviceId, RpcStatus.QUEUED, null));
+        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(UUID.randomUUID(), deviceId, RpcStatus.SENT, null));
+        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(UUID.randomUUID(), deviceId, RpcStatus.DELIVERED, null));
+        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(UUID.randomUUID(), deviceId, RpcStatus.SUCCESSFUL, null));
+
+        List<Rpc> inFlight = rpcDao.findAllByDeviceIdAndStatusIn(TenantId.SYS_TENANT_ID, deviceId,
+                List.of(RpcStatus.QUEUED, RpcStatus.SENT, RpcStatus.DELIVERED), new PageLink(100)).getData();
+
+        // the terminal SUCCESSFUL row is excluded; only the three in-flight statuses come back:
+        assertThat(inFlight).extracting(Rpc::getStatus)
+                .containsExactlyInAnyOrder(RpcStatus.QUEUED, RpcStatus.SENT, RpcStatus.DELIVERED);
     }
 
     private Rpc rpc(UUID id, DeviceId deviceId, RpcStatus status, JsonNode response) {


### PR DESCRIPTION
## Problem

During a tb-core rolling restart / device-actor migration, in-flight RPCs were lost: persistent RPCs got stuck in `DELIVERED` forever and were never re-published or resolved (~47% loss observed in load testing). Root cause: the per-actor `rpcSeq` counter resets to `0` when the actor is recreated, and the actor did not reload the in-flight (`SENT`/`DELIVERED`) rows it had persisted, so responses arriving after the move could not be matched back to a request.

## Goal

Persistent RPCs = zero-loss and no mis-match across a core rollout. Non-persistent RPCs remain best-effort (unchanged).

## Approach

Persist the transport `requestId` on the `rpc` row and rebuild actor state from it on `init()`:

- **Schema** — nullable `request_id` and `oneway` columns on `rpc`, plus a partial index `idx_rpc_in_flight`, applied via the LTS `4.3.1.4` patch (auto-applies on core startup through `SystemPatchApplier`; nullable so pre-migration rows load fine).
- **Persist** — the integer `requestId` and the `oneway` flag are written to the row at RPC creation.
- **Reload (one-way-aware)** — on actor `init()`, in-flight rows are reloaded under their persisted id, sorted by `createdTime` (then `requestId`) to preserve submission order, and their timeouts re-armed. The reload query + partial index deliberately exclude one-way `DELIVERED` (a terminal success that would otherwise accumulate and be loaded for nothing).
- **Seed** — `rpcSeq` is seeded once past the highest reloaded id, so a new RPC never collides with a reloaded one; with nothing in flight it still starts from `0` (the gateway dedups in-flight only and forgets an id once answered).
- **Never re-publish an answered RPC** — `DELIVERED` is terminal for re-publication; on resubscribe it is not pushed again (removes a latent double-execution). One-way `SENT` is re-published (only one-way `DELIVERED` is terminal); a null/corrupt persisted request is logged and skipped without aborting the reload.
- **Legacy backlog** — rows written before this feature have no `request_id` and can't be tracked across the upgrade: `QUEUED` are still delivered; stuck `SENT` / two-way `DELIVERED` are closed to a terminal state with an explanatory response. The bulk cleanup runs **outside** the schema transaction, in keyset-paginated self-committing batches (a ported `applyAfterCommit` LTS hook) so it never blocks a serving node; rolling-window stragglers are closed by the actor's reload guard.

No proto / wire / device / transport change. Transport and rule-engine rolls are unaffected — the reload path runs only when the actor is recreated.

## Tests

- `DeviceActorMessageProcessorTest` — reload/seed/guard behavior: persist-on-create, `DELIVERED` reload matches a late device response, one-way `DELIVERED` not re-expired, one-way `SENT` re-published, legacy null-`request_id` `SENT` closed (not re-published), rpcSeq seeding, resubscribe skips `DELIVERED`.
- `JpaRpcDaoTest` — `request_id`/`oneway` DB round-trip and the reload query excluding one-way `DELIVERED` / terminal rows.
- `V4_3_1_4MigrationIntegrationTest` — the batched `applyAfterCommit()` cleanup driven across multiple keyset windows against a real DB: only stuck legacy rows are closed; one-way `DELIVERED`, future-expiry, tracked (`request_id` set) and `QUEUED` rows are left untouched.
- `LtsMigrationServiceTest` / `LtsMigrationIntegrationTest` — the two-phase `applyMigrations` (schema, then out-of-transaction backfill, then version record) and dir↔bean pairing.
