### PR TITLE
Idempotent persistent-RPC creation under re-delivery

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -205,20 +205,25 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         if (timeout <= 0) {
             log.debug("[{}][{}] Ignoring message due to exp time reached, {}", deviceId, rpcId, request.getExpirationTime());
             if (persisted) {
-                createRpc(request, RpcStatus.EXPIRED, createdTime, requestId);
+                createRpcIfAbsent(request, RpcStatus.EXPIRED, createdTime, requestId);
                 // Reply even though the command expired, so the caller can read the EXPIRED row instead of waiting
                 // out the core's safety net for an opaque TIMEOUT. Not gated on the create result: the reply
                 // carries only the id, and completion is remove-once.
                 sendRpcIdResponse(rpcId);
             }
             return;
-        } else if (persisted && !createRpc(request, RpcStatus.QUEUED, createdTime, requestId)) {
-            // The existing row owns delivery - via its live pending entry, or via the reload on actor init.
-            // Re-sending here would execute the command twice on the device.
-            log.debug("[{}][{}] Duplicate persistent RPC delivery - skipping device send and pending registration",
-                    deviceId, rpcId);
-            sendRpcIdResponse(rpcId);
-            return;
+        }
+
+        if (persisted) {
+            boolean created = createRpcIfAbsent(request, RpcStatus.QUEUED, createdTime, requestId);
+            if (!created) {
+                // The existing row owns delivery - via its live pending entry, or via the reload on actor init.
+                // Re-sending here would execute the command twice on the device.
+                log.debug("[{}][{}] Duplicate persistent RPC delivery - skipping device send and pending registration",
+                        deviceId, rpcId);
+                sendRpcIdResponse(rpcId);
+                return;
+            }
         }
 
         boolean sent = false;
@@ -273,8 +278,8 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         return !md.isDelivered();
     }
 
-    private boolean createRpc(ToDeviceRpcRequest request, RpcStatus status, long createdTime, int requestId) {
-        return systemContext.getTbRpcService().create(tenantId, buildRpc(request, status, null, createdTime, requestId));
+    private boolean createRpcIfAbsent(ToDeviceRpcRequest request, RpcStatus status, long createdTime, int requestId) {
+        return systemContext.getTbRpcService().createIfAbsent(tenantId, buildRpc(request, status, null, createdTime, requestId));
     }
 
     private void sendRpcIdResponse(UUID rpcId) {

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -205,17 +205,16 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         if (timeout <= 0) {
             log.debug("[{}][{}] Ignoring message due to exp time reached, {}", deviceId, rpcId, request.getExpirationTime());
             if (persisted) {
-                createRpc(request, RpcStatus.EXPIRED, createdTime, requestId); // no-op if the row already exists
-                // Hand the id back even though the command expired, so the caller can read the EXPIRED row
-                // instead of waiting out the core's safety net for an opaque TIMEOUT. Not gated on the create
-                // result: the reply carries only the id, and completion is remove-once.
+                createRpc(request, RpcStatus.EXPIRED, createdTime, requestId);
+                // Reply even though the command expired, so the caller can read the EXPIRED row instead of waiting
+                // out the core's safety net for an opaque TIMEOUT. Not gated on the create result: the reply
+                // carries only the id, and completion is remove-once.
                 sendRpcIdResponse(rpcId);
             }
             return;
         } else if (persisted && !createRpc(request, RpcStatus.QUEUED, createdTime, requestId)) {
-            // Re-delivery of a command we already persisted (same rpcId). The existing row owns delivery - via its
-            // live pending entry, or via the reload on actor init. Re-sending here would execute it twice on the
-            // device. Still hand the id back so the caller's callback completes.
+            // The existing row owns delivery - via its live pending entry, or via the reload on actor init.
+            // Re-sending here would execute the command twice on the device.
             log.debug("[{}][{}] Duplicate persistent RPC delivery - skipping device send and pending registration",
                     deviceId, rpcId);
             sendRpcIdResponse(rpcId);

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -205,11 +205,21 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         if (timeout <= 0) {
             log.debug("[{}][{}] Ignoring message due to exp time reached, {}", deviceId, rpcId, request.getExpirationTime());
             if (persisted) {
-                createRpc(request, RpcStatus.EXPIRED, createdTime, requestId);
+                createRpc(request, RpcStatus.EXPIRED, createdTime, requestId); // no-op if the row already exists
+                // Hand the id back even though the command expired, so the caller can read the EXPIRED row
+                // instead of waiting out the core's safety net for an opaque TIMEOUT. Not gated on the create
+                // result: the reply carries only the id, and completion is remove-once.
+                sendRpcIdResponse(rpcId);
             }
             return;
-        } else if (persisted) {
-            createRpc(request, RpcStatus.QUEUED, createdTime, requestId);
+        } else if (persisted && !createRpc(request, RpcStatus.QUEUED, createdTime, requestId)) {
+            // Re-delivery of a command we already persisted (same rpcId). The existing row owns delivery - via its
+            // live pending entry, or via the reload on actor init. Re-sending here would execute it twice on the
+            // device. Still hand the id back so the caller's callback completes.
+            log.debug("[{}][{}] Duplicate persistent RPC delivery - skipping device send and pending registration",
+                    deviceId, rpcId);
+            sendRpcIdResponse(rpcId);
+            return;
         }
 
         boolean sent = false;
@@ -239,9 +249,7 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         }
 
         if (persisted) {
-            ObjectNode response = JacksonUtil.newObjectNode();
-            response.put("rpcId", rpcId.toString());
-            systemContext.getTbCoreDeviceRpcService().processRpcResponseFromDeviceActor(new FromDeviceRpcResponse(rpcId, JacksonUtil.toString(response), null));
+            sendRpcIdResponse(rpcId);
         }
 
         if (!persisted && request.isOneway() && sent) {
@@ -266,8 +274,15 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         return !md.isDelivered();
     }
 
-    private void createRpc(ToDeviceRpcRequest request, RpcStatus status, long createdTime, int requestId) {
-        systemContext.getTbRpcService().create(tenantId, buildRpc(request, status, null, createdTime, requestId));
+    private boolean createRpc(ToDeviceRpcRequest request, RpcStatus status, long createdTime, int requestId) {
+        return systemContext.getTbRpcService().create(tenantId, buildRpc(request, status, null, createdTime, requestId));
+    }
+
+    private void sendRpcIdResponse(UUID rpcId) {
+        ObjectNode response = JacksonUtil.newObjectNode();
+        response.put("rpcId", rpcId.toString());
+        systemContext.getTbCoreDeviceRpcService().processRpcResponseFromDeviceActor(
+                new FromDeviceRpcResponse(rpcId, JacksonUtil.toString(response), null));
     }
 
     private Rpc buildRpc(ToDeviceRpcRequest request, RpcStatus status, JsonNode response, long createdTime, int requestId) {

--- a/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
+++ b/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
@@ -71,9 +71,12 @@ public class TbRpcService {
         }
     }
 
-    public void create(TenantId tenantId, Rpc rpc) {
-        rpcService.save(rpc);
-        executorFor(rpc.getUuidId()).execute(() -> notifyRuleEngine(tenantId, rpc));
+    public boolean create(TenantId tenantId, Rpc rpc) {
+        boolean inserted = rpcService.create(rpc);
+        if (inserted) {
+            executorFor(rpc.getUuidId()).execute(() -> notifyRuleEngine(tenantId, rpc));
+        }
+        return inserted;
     }
 
     public void update(TenantId tenantId, Rpc rpc) {

--- a/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
+++ b/application/src/main/java/org/thingsboard/server/service/rpc/TbRpcService.java
@@ -71,8 +71,8 @@ public class TbRpcService {
         }
     }
 
-    public boolean create(TenantId tenantId, Rpc rpc) {
-        boolean inserted = rpcService.create(rpc);
+    public boolean createIfAbsent(TenantId tenantId, Rpc rpc) {
+        boolean inserted = rpcService.createIfAbsent(rpc);
         if (inserted) {
             executorFor(rpc.getUuidId()).execute(() -> notifyRuleEngine(tenantId, rpc));
         }

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -113,13 +113,10 @@ public class DeviceActorMessageProcessorTest {
         mockRpcInfra();
 
         TbActorCtx ctx = mock(TbActorCtx.class);
-        ToDeviceRpcRequest request = new ToDeviceRpcRequest(UUID.randomUUID(), tenantId, deviceId,
-                false, System.currentTimeMillis() + 60_000, new ToDeviceRpcRequestBody("m", "{}"),
-                true, null, null); // persisted=true, oneway=false
-        processor.processRpcRequest(ctx, new ToDeviceRpcRequestActorMsg("svc", request));
+        processor.processRpcRequest(ctx, new ToDeviceRpcRequestActorMsg("svc", persistedRequest(UUID.randomUUID())));
 
         ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
-        verify(rpcService).create(eq(tenantId), captor.capture());
+        verify(rpcService).createIfAbsent(eq(tenantId), captor.capture());
         assertThat(captor.getValue().getRequestId()).isEqualTo(0); // first rpcSeq
     }
 
@@ -204,12 +201,11 @@ public class DeviceActorMessageProcessorTest {
         processor.init(mock(TbActorCtx.class));
 
         // next brand-new persistent RPC must get id 6, not 0:
-        ToDeviceRpcRequest req = new ToDeviceRpcRequest(UUID.randomUUID(), tenantId, deviceId, false,
-                System.currentTimeMillis() + 60_000, new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
-        processor.processRpcRequest(mock(TbActorCtx.class), new ToDeviceRpcRequestActorMsg("svc", req));
+        processor.processRpcRequest(mock(TbActorCtx.class),
+                new ToDeviceRpcRequestActorMsg("svc", persistedRequest(UUID.randomUUID())));
 
         ArgumentCaptor<Rpc> captor = ArgumentCaptor.forClass(Rpc.class);
-        verify(rpcService).create(eq(tenantId), captor.capture());
+        verify(rpcService).createIfAbsent(eq(tenantId), captor.capture());
         assertThat(captor.getValue().getRequestId()).isEqualTo(6);
     }
 
@@ -305,20 +301,23 @@ public class DeviceActorMessageProcessorTest {
 
     @Test
     public void firstPersistedRpcRegistersAndSendsAsBefore() {
-        mockRpcInfra(); // create -> true
+        mockRpcInfra(); // createIfAbsent -> true
+        UUID rpcId = UUID.randomUUID();
         subscribeAsyncSession();
 
         processor.processRpcRequest(mock(TbActorCtx.class),
-                new ToDeviceRpcRequestActorMsg("svc", persistedRequest(UUID.randomUUID())));
+                new ToDeviceRpcRequestActorMsg("svc", persistedRequest(rpcId)));
 
-        // The non-duplicate path must be untouched by the restructure: the command still reaches the device.
+        // The non-duplicate path must be untouched by the restructure: the command still reaches the device,
+        // and the caller still gets its id back.
         assertThat(publishedRequestIds()).containsExactly(0); // first rpcSeq
+        assertRpcIdReplied(rpcId);
     }
 
     @Test
     public void duplicatePersistedRpcSkipsSendAndPendingRegistration() {
         mockRpcInfra();
-        given(rpcService.create(any(), any())).willReturn(false); // insert-if-absent matched an existing row
+        given(rpcService.createIfAbsent(any(), any())).willReturn(false); // insert-if-absent matched an existing row
         UUID sessionId = subscribeAsyncSession(); // active subscription: a send WOULD happen if not skipped
 
         processor.processRpcRequest(mock(TbActorCtx.class),
@@ -334,7 +333,7 @@ public class DeviceActorMessageProcessorTest {
     @Test
     public void duplicatePersistedRpcStillReturnsRpcIdToCaller() {
         mockRpcInfra();
-        given(rpcService.create(any(), any())).willReturn(false);
+        given(rpcService.createIfAbsent(any(), any())).willReturn(false);
         UUID rpcId = UUID.randomUUID();
 
         processor.processRpcRequest(mock(TbActorCtx.class),
@@ -342,11 +341,7 @@ public class DeviceActorMessageProcessorTest {
 
         // The caller still gets its id back: completion is keyed by rpcId and remove-once, so replying for a
         // duplicate is harmless - but NOT replying would hang the REST DeferredResult / rule-node callback.
-        ArgumentCaptor<FromDeviceRpcResponse> captor = ArgumentCaptor.forClass(FromDeviceRpcResponse.class);
-        verify(coreRpcService).processRpcResponseFromDeviceActor(captor.capture());
-        assertThat(captor.getValue().getId()).isEqualTo(rpcId);
-        assertThat(JacksonUtil.toJsonNode(captor.getValue().getResponse().orElseThrow()).get("rpcId").asText())
-                .isEqualTo(rpcId.toString());
+        assertRpcIdReplied(rpcId);
     }
 
     @Test
@@ -361,21 +356,17 @@ public class DeviceActorMessageProcessorTest {
         // D6: the EXPIRED row is written AND the caller gets its id, so it can read that row instead of waiting
         // out the core's safety net for an opaque TIMEOUT. Never sent to the device - it is already expired.
         ArgumentCaptor<Rpc> rpcCaptor = ArgumentCaptor.forClass(Rpc.class);
-        verify(rpcService).create(eq(tenantId), rpcCaptor.capture());
+        verify(rpcService).createIfAbsent(eq(tenantId), rpcCaptor.capture());
         assertThat(rpcCaptor.getValue().getStatus()).isEqualTo(RpcStatus.EXPIRED);
         verify(toTransport, never()).process(any(), any());
 
-        ArgumentCaptor<FromDeviceRpcResponse> captor = ArgumentCaptor.forClass(FromDeviceRpcResponse.class);
-        verify(coreRpcService).processRpcResponseFromDeviceActor(captor.capture());
-        assertThat(captor.getValue().getId()).isEqualTo(rpcId);
-        assertThat(JacksonUtil.toJsonNode(captor.getValue().getResponse().orElseThrow()).get("rpcId").asText())
-                .isEqualTo(rpcId.toString());
+        assertRpcIdReplied(rpcId);
     }
 
     @Test
     public void duplicateExpiredOnArrivalRpcIsNoOpButStillReplies() {
         mockRpcInfra();
-        given(rpcService.create(any(), any())).willReturn(false); // row already exists from an earlier delivery
+        given(rpcService.createIfAbsent(any(), any())).willReturn(false); // row already exists from an earlier delivery
         UUID rpcId = UUID.randomUUID();
         subscribeAsyncSession();
 
@@ -384,15 +375,15 @@ public class DeviceActorMessageProcessorTest {
 
         // Insert-if-absent turns the EXPIRED create into a no-op, so an already-SUCCESSFUL row is not clobbered.
         // The reply is NOT gated on the insert result: it carries only the id, and completion is remove-once.
-        verify(rpcService).create(eq(tenantId), any());
+        verify(rpcService).createIfAbsent(eq(tenantId), any());
         verify(toTransport, never()).process(any(), any());
-        verify(coreRpcService).processRpcResponseFromDeviceActor(any());
+        assertRpcIdReplied(rpcId);
     }
 
     private void mockRpcInfra() {
         rpcService = mock(TbRpcService.class);
         // Default: a brand-new command, so insert-if-absent reports a real insert. Duplicate tests override this.
-        given(rpcService.create(any(), any())).willReturn(true);
+        given(rpcService.createIfAbsent(any(), any())).willReturn(true);
         given(systemContext.getTbRpcService()).willReturn(rpcService);
         coreRpcService = mock(TbCoreDeviceRpcService.class);
         given(systemContext.getTbCoreDeviceRpcService()).willReturn(coreRpcService);
@@ -422,14 +413,29 @@ public class DeviceActorMessageProcessorTest {
     }
 
     private ToDeviceRpcRequest persistedRequest(UUID rpcId) {
-        return new ToDeviceRpcRequest(rpcId, tenantId, deviceId, false, System.currentTimeMillis() + 60_000,
-                new ToDeviceRpcRequestBody("m", "{}"), true, null, null); // persisted=true, oneway=false
+        return persistedRequest(rpcId, System.currentTimeMillis() + 60_000);
+    }
+
+    private ToDeviceRpcRequest persistedRequest(UUID rpcId, long expirationTime) {
+        return persistedRequest(rpcId, expirationTime, false);
+    }
+
+    private ToDeviceRpcRequest persistedRequest(UUID rpcId, long expirationTime, boolean oneway) {
+        return new ToDeviceRpcRequest(rpcId, tenantId, deviceId, oneway, expirationTime,
+                new ToDeviceRpcRequestBody("m", "{}"), true, null, null); // persisted=true
     }
 
     private ToDeviceRpcRequest expiredRequest(UUID rpcId) {
         // expirationTime already in the past -> the actor's `timeout <= 0` branch
-        return new ToDeviceRpcRequest(rpcId, tenantId, deviceId, false, System.currentTimeMillis() - 1,
-                new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
+        return persistedRequest(rpcId, System.currentTimeMillis() - 1);
+    }
+
+    private void assertRpcIdReplied(UUID rpcId) {
+        ArgumentCaptor<FromDeviceRpcResponse> captor = ArgumentCaptor.forClass(FromDeviceRpcResponse.class);
+        verify(coreRpcService).processRpcResponseFromDeviceActor(captor.capture());
+        assertThat(captor.getValue().getId()).isEqualTo(rpcId);
+        assertThat(JacksonUtil.toJsonNode(captor.getValue().getResponse().orElseThrow()).get("rpcId").asText())
+                .isEqualTo(rpcId.toString());
     }
 
     private List<Integer> publishedRequestIds() {
@@ -462,8 +468,7 @@ public class DeviceActorMessageProcessorTest {
     }
 
     private Rpc row(UUID rpcUuid, RpcStatus status, long createdTime, long expirationTime, boolean oneway) {
-        ToDeviceRpcRequest req = new ToDeviceRpcRequest(rpcUuid, tenantId, deviceId, oneway, expirationTime,
-                new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
+        ToDeviceRpcRequest req = persistedRequest(rpcUuid, expirationTime, oneway);
         Rpc rpc = new Rpc(new RpcId(rpcUuid));
         rpc.setCreatedTime(createdTime);
         rpc.setExpirationTime(expirationTime);

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -30,6 +30,7 @@ import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.rpc.Rpc;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.common.data.rpc.ToDeviceRpcRequestBody;
+import org.thingsboard.server.common.msg.rpc.FromDeviceRpcResponse;
 import org.thingsboard.server.common.msg.rpc.ToDeviceRpcRequest;
 import org.thingsboard.server.common.msg.rpc.ToDeviceRpcRequestActorMsg;
 import org.thingsboard.server.dao.device.DeviceService;
@@ -64,6 +65,7 @@ public class DeviceActorMessageProcessorTest {
 
     DeviceActorMessageProcessor processor;
     TbRpcService rpcService;
+    TbCoreDeviceRpcService coreRpcService;
     TbCoreToTransportService toTransport;
 
     @Before
@@ -301,10 +303,99 @@ public class DeviceActorMessageProcessorTest {
         verify(toTransport, never()).process(any(), any());
     }
 
+    @Test
+    public void firstPersistedRpcRegistersAndSendsAsBefore() {
+        mockRpcInfra(); // create -> true
+        subscribeAsyncSession();
+
+        processor.processRpcRequest(mock(TbActorCtx.class),
+                new ToDeviceRpcRequestActorMsg("svc", persistedRequest(UUID.randomUUID())));
+
+        // The non-duplicate path must be untouched by the restructure: the command still reaches the device.
+        assertThat(publishedRequestIds()).containsExactly(0); // first rpcSeq
+    }
+
+    @Test
+    public void duplicatePersistedRpcSkipsSendAndPendingRegistration() {
+        mockRpcInfra();
+        given(rpcService.create(any(), any())).willReturn(false); // insert-if-absent matched an existing row
+        UUID sessionId = subscribeAsyncSession(); // active subscription: a send WOULD happen if not skipped
+
+        processor.processRpcRequest(mock(TbActorCtx.class),
+                new ToDeviceRpcRequestActorMsg("svc", persistedRequest(UUID.randomUUID())));
+
+        // Not sent while processing - the existing row owns delivery, re-sending would double-execute.
+        verify(toTransport, never()).process(any(), any());
+        // ...and nothing was registered as pending, so a later push has nothing to deliver either.
+        processor.sendPendingRequests(sessionId, "svc");
+        verify(toTransport, never()).process(any(), any());
+    }
+
+    @Test
+    public void duplicatePersistedRpcStillReturnsRpcIdToCaller() {
+        mockRpcInfra();
+        given(rpcService.create(any(), any())).willReturn(false);
+        UUID rpcId = UUID.randomUUID();
+
+        processor.processRpcRequest(mock(TbActorCtx.class),
+                new ToDeviceRpcRequestActorMsg("svc", persistedRequest(rpcId)));
+
+        // The caller still gets its id back: completion is keyed by rpcId and remove-once, so replying for a
+        // duplicate is harmless - but NOT replying would hang the REST DeferredResult / rule-node callback.
+        ArgumentCaptor<FromDeviceRpcResponse> captor = ArgumentCaptor.forClass(FromDeviceRpcResponse.class);
+        verify(coreRpcService).processRpcResponseFromDeviceActor(captor.capture());
+        assertThat(captor.getValue().getId()).isEqualTo(rpcId);
+        assertThat(JacksonUtil.toJsonNode(captor.getValue().getResponse().orElseThrow()).get("rpcId").asText())
+                .isEqualTo(rpcId.toString());
+    }
+
+    @Test
+    public void expiredOnArrivalRpcReturnsRpcIdToCaller() {
+        mockRpcInfra(); // create -> true: first delivery of a command that arrived past its expiration
+        UUID rpcId = UUID.randomUUID();
+        subscribeAsyncSession();
+
+        processor.processRpcRequest(mock(TbActorCtx.class),
+                new ToDeviceRpcRequestActorMsg("svc", expiredRequest(rpcId)));
+
+        // D6: the EXPIRED row is written AND the caller gets its id, so it can read that row instead of waiting
+        // out the core's safety net for an opaque TIMEOUT. Never sent to the device - it is already expired.
+        ArgumentCaptor<Rpc> rpcCaptor = ArgumentCaptor.forClass(Rpc.class);
+        verify(rpcService).create(eq(tenantId), rpcCaptor.capture());
+        assertThat(rpcCaptor.getValue().getStatus()).isEqualTo(RpcStatus.EXPIRED);
+        verify(toTransport, never()).process(any(), any());
+
+        ArgumentCaptor<FromDeviceRpcResponse> captor = ArgumentCaptor.forClass(FromDeviceRpcResponse.class);
+        verify(coreRpcService).processRpcResponseFromDeviceActor(captor.capture());
+        assertThat(captor.getValue().getId()).isEqualTo(rpcId);
+        assertThat(JacksonUtil.toJsonNode(captor.getValue().getResponse().orElseThrow()).get("rpcId").asText())
+                .isEqualTo(rpcId.toString());
+    }
+
+    @Test
+    public void duplicateExpiredOnArrivalRpcIsNoOpButStillReplies() {
+        mockRpcInfra();
+        given(rpcService.create(any(), any())).willReturn(false); // row already exists from an earlier delivery
+        UUID rpcId = UUID.randomUUID();
+        subscribeAsyncSession();
+
+        processor.processRpcRequest(mock(TbActorCtx.class),
+                new ToDeviceRpcRequestActorMsg("svc", expiredRequest(rpcId)));
+
+        // Insert-if-absent turns the EXPIRED create into a no-op, so an already-SUCCESSFUL row is not clobbered.
+        // The reply is NOT gated on the insert result: it carries only the id, and completion is remove-once.
+        verify(rpcService).create(eq(tenantId), any());
+        verify(toTransport, never()).process(any(), any());
+        verify(coreRpcService).processRpcResponseFromDeviceActor(any());
+    }
+
     private void mockRpcInfra() {
         rpcService = mock(TbRpcService.class);
+        // Default: a brand-new command, so insert-if-absent reports a real insert. Duplicate tests override this.
+        given(rpcService.create(any(), any())).willReturn(true);
         given(systemContext.getTbRpcService()).willReturn(rpcService);
-        given(systemContext.getTbCoreDeviceRpcService()).willReturn(mock(TbCoreDeviceRpcService.class));
+        coreRpcService = mock(TbCoreDeviceRpcService.class);
+        given(systemContext.getTbCoreDeviceRpcService()).willReturn(coreRpcService);
         given(systemContext.getServiceId()).willReturn("svc");
         toTransport = mock(TbCoreToTransportService.class);
         given(systemContext.getTbCoreToTransportService()).willReturn(toTransport);
@@ -319,11 +410,26 @@ public class DeviceActorMessageProcessorTest {
     }
 
     private void pushViaAsyncSession() {
+        processor.sendPendingRequests(subscribeAsyncSession(), "svc");
+    }
+
+    private UUID subscribeAsyncSession() {
         UUID sessionId = UUID.randomUUID();
         SessionInfo sessionInfo = new SessionInfo(SessionType.ASYNC, "svc");
         processor.sessions.put(sessionId, new SessionInfoMetaData(sessionInfo));
         processor.rpcSubscriptions.put(sessionId, sessionInfo);
-        processor.sendPendingRequests(sessionId, "svc");
+        return sessionId;
+    }
+
+    private ToDeviceRpcRequest persistedRequest(UUID rpcId) {
+        return new ToDeviceRpcRequest(rpcId, tenantId, deviceId, false, System.currentTimeMillis() + 60_000,
+                new ToDeviceRpcRequestBody("m", "{}"), true, null, null); // persisted=true, oneway=false
+    }
+
+    private ToDeviceRpcRequest expiredRequest(UUID rpcId) {
+        // expirationTime already in the past -> the actor's `timeout <= 0` branch
+        return new ToDeviceRpcRequest(rpcId, tenantId, deviceId, false, System.currentTimeMillis() - 1,
+                new ToDeviceRpcRequestBody("m", "{}"), true, null, null);
     }
 
     private List<Integer> publishedRequestIds() {

--- a/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessorTest.java
@@ -353,7 +353,7 @@ public class DeviceActorMessageProcessorTest {
         processor.processRpcRequest(mock(TbActorCtx.class),
                 new ToDeviceRpcRequestActorMsg("svc", expiredRequest(rpcId)));
 
-        // D6: the EXPIRED row is written AND the caller gets its id, so it can read that row instead of waiting
+        // The EXPIRED row is written AND the caller gets its id, so it can read that row instead of waiting
         // out the core's safety net for an opaque TIMEOUT. Never sent to the device - it is already expired.
         ArgumentCaptor<Rpc> rpcCaptor = ArgumentCaptor.forClass(Rpc.class);
         verify(rpcService).createIfAbsent(eq(tenantId), rpcCaptor.capture());

--- a/application/src/test/java/org/thingsboard/server/service/rpc/TbRpcServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/rpc/TbRpcServiceTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -72,16 +73,30 @@ public class TbRpcServiceTest {
     }
 
     @Test
-    public void createPersistsSynchronouslyThenPushesToRuleEngine() {
+    public void createReturnsTrueAndPushesToRuleEngineWhenInserted() {
         Rpc rpc = newRpc();
-        when(rpcService.save(rpc)).thenReturn(rpc);
+        when(rpcService.create(rpc)).thenReturn(true);
 
-        tbRpcService.create(rpc.getTenantId(), rpc);
+        // create must persist synchronously via the insert-if-absent path
+        assertTrue(tbRpcService.create(rpc.getTenantId(), rpc));
 
-        // create must persist synchronously via save(...)
-        verify(rpcService).save(rpc);
+        verify(rpcService).create(rpc);
         verify(clusterService, timeout(5000))
                 .pushMsgToRuleEngine(eq(rpc.getTenantId()), eq(rpc.getDeviceId()), any(TbMsg.class), isNull());
+    }
+
+    @Test
+    public void createDoesNotNotifyRuleEngineOnDuplicate() {
+        Rpc rpc = newRpc();
+        // Insert-if-absent matched an existing row: this command was already created by an earlier delivery,
+        // so publishing a second RPC_QUEUED for it would be a spurious, duplicate lifecycle event.
+        when(rpcService.create(rpc)).thenReturn(false);
+
+        assertFalse(tbRpcService.create(rpc.getTenantId(), rpc));
+
+        verify(rpcService).create(rpc);
+        verify(clusterService, after(500).never())
+                .pushMsgToRuleEngine(any(TenantId.class), any(DeviceId.class), any(TbMsg.class), isNull());
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/server/service/rpc/TbRpcServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/rpc/TbRpcServiceTest.java
@@ -73,28 +73,28 @@ public class TbRpcServiceTest {
     }
 
     @Test
-    public void createReturnsTrueAndPushesToRuleEngineWhenInserted() {
+    public void createIfAbsentReturnsTrueAndPushesToRuleEngineWhenInserted() {
         Rpc rpc = newRpc();
-        when(rpcService.create(rpc)).thenReturn(true);
+        when(rpcService.createIfAbsent(rpc)).thenReturn(true);
 
         // create must persist synchronously via the insert-if-absent path
-        assertTrue(tbRpcService.create(rpc.getTenantId(), rpc));
+        assertTrue(tbRpcService.createIfAbsent(rpc.getTenantId(), rpc));
 
-        verify(rpcService).create(rpc);
+        verify(rpcService).createIfAbsent(rpc);
         verify(clusterService, timeout(5000))
                 .pushMsgToRuleEngine(eq(rpc.getTenantId()), eq(rpc.getDeviceId()), any(TbMsg.class), isNull());
     }
 
     @Test
-    public void createDoesNotNotifyRuleEngineOnDuplicate() {
+    public void createIfAbsentDoesNotNotifyRuleEngineOnDuplicate() {
         Rpc rpc = newRpc();
         // Insert-if-absent matched an existing row: this command was already created by an earlier delivery,
         // so publishing a second RPC_QUEUED for it would be a spurious, duplicate lifecycle event.
-        when(rpcService.create(rpc)).thenReturn(false);
+        when(rpcService.createIfAbsent(rpc)).thenReturn(false);
 
-        assertFalse(tbRpcService.create(rpc.getTenantId(), rpc));
+        assertFalse(tbRpcService.createIfAbsent(rpc.getTenantId(), rpc));
 
-        verify(rpcService).create(rpc);
+        verify(rpcService).createIfAbsent(rpc);
         verify(clusterService, after(500).never())
                 .pushMsgToRuleEngine(any(TenantId.class), any(DeviceId.class), any(TbMsg.class), isNull());
     }

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/rpc/RpcService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/rpc/RpcService.java
@@ -33,7 +33,7 @@ public interface RpcService extends EntityDaoService {
      *
      * @return true if a row was inserted, false if a row with this id already existed
      */
-    boolean create(Rpc rpc);
+    boolean createIfAbsent(Rpc rpc);
 
     ListenableFuture<Boolean> updateAsync(Rpc rpc);
 

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/rpc/RpcService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/rpc/RpcService.java
@@ -27,7 +27,13 @@ import org.thingsboard.server.dao.entity.EntityDaoService;
 
 public interface RpcService extends EntityDaoService {
 
-    Rpc save(Rpc rpc);
+    /**
+     * Insert-if-absent. Persists the RPC only if no row with this id exists, so a re-delivered command is a
+     * no-op rather than an upsert that resurrects or clobbers the existing row.
+     *
+     * @return true if a row was inserted, false if a row with this id already existed
+     */
+    boolean create(Rpc rpc);
 
     ListenableFuture<Boolean> updateAsync(Rpc rpc);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/rpc/BaseRpcService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rpc/BaseRpcService.java
@@ -49,9 +49,9 @@ public class BaseRpcService implements RpcService {
     private final RpcDao rpcDao;
 
     @Override
-    public Rpc save(Rpc rpc) {
-        log.trace("Executing save, [{}]", rpc);
-        return rpcDao.save(rpc.getTenantId(), rpc);
+    public boolean create(Rpc rpc) {
+        log.trace("Executing create, [{}]", rpc);
+        return rpcDao.createIfAbsent(rpc.getTenantId(), rpc);
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/rpc/BaseRpcService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rpc/BaseRpcService.java
@@ -49,14 +49,16 @@ public class BaseRpcService implements RpcService {
     private final RpcDao rpcDao;
 
     @Override
-    public boolean create(Rpc rpc) {
-        log.trace("Executing create, [{}]", rpc);
-        return rpcDao.createIfAbsent(rpc.getTenantId(), rpc);
+    public boolean createIfAbsent(Rpc rpc) {
+        log.trace("Executing createIfAbsent, tenantId [{}], deviceId [{}], rpcId [{}], status [{}]",
+                rpc.getTenantId(), rpc.getDeviceId(), rpc.getId(), rpc.getStatus());
+        return rpcDao.createIfAbsent(rpc);
     }
 
     @Override
     public ListenableFuture<Boolean> updateAsync(Rpc rpc) {
-        log.trace("Executing updateAsync, [{}]", rpc);
+        log.trace("Executing updateAsync, tenantId [{}], deviceId [{}], rpcId [{}], status [{}]",
+                rpc.getTenantId(), rpc.getDeviceId(), rpc.getId(), rpc.getStatus());
         return rpcDao.updateAsync(rpc);
     }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/rpc/RpcDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rpc/RpcDao.java
@@ -31,7 +31,7 @@ public interface RpcDao extends Dao<Rpc> {
      *
      * @return true if a row was inserted, false if a row with this id already existed
      */
-    boolean createIfAbsent(TenantId tenantId, Rpc rpc);
+    boolean createIfAbsent(Rpc rpc);
 
     ListenableFuture<Boolean> updateAsync(Rpc rpc);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/rpc/RpcDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rpc/RpcDao.java
@@ -26,6 +26,15 @@ import org.thingsboard.server.dao.Dao;
 
 public interface RpcDao extends Dao<Rpc> {
 
+    /**
+     * Insert-if-absent. The create path is idempotent by rpcId: a re-delivered command must not overwrite the
+     * row created by the first delivery. Deliberately not named save(...) - the inherited {@link Dao#save} is
+     * the unconditional upsert this method exists to avoid.
+     *
+     * @return true if a row was inserted, false if a row with this id already existed
+     */
+    boolean createIfAbsent(TenantId tenantId, Rpc rpc);
+
     ListenableFuture<Boolean> updateAsync(Rpc rpc);
 
     PageData<Rpc> findAllByDeviceId(TenantId tenantId, DeviceId deviceId, PageLink pageLink);

--- a/dao/src/main/java/org/thingsboard/server/dao/rpc/RpcDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rpc/RpcDao.java
@@ -27,9 +27,7 @@ import org.thingsboard.server.dao.Dao;
 public interface RpcDao extends Dao<Rpc> {
 
     /**
-     * Insert-if-absent. The create path is idempotent by rpcId: a re-delivered command must not overwrite the
-     * row created by the first delivery. Deliberately not named save(...) - the inherited {@link Dao#save} is
-     * the unconditional upsert this method exists to avoid.
+     * Idempotent by rpcId: a re-delivered command must not overwrite the row created by the first delivery.
      *
      * @return true if a row was inserted, false if a row with this id already existed
      */

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDao.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.dao.sql.rpc;
 
+import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.google.common.util.concurrent.ListenableFuture;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -53,6 +54,7 @@ import java.util.function.Function;
 public class JpaRpcDao extends JpaAbstractDao<RpcEntity, Rpc> implements RpcDao, TenantEntityDao<Rpc> {
 
     private final RpcRepository rpcRepository;
+    private final RpcInsertRepository rpcInsertRepository;
     private final RpcUpdateRepository rpcUpdateRepository;
     private final ScheduledLogExecutorComponent logExecutor;
     private final StatsFactory statsFactory;
@@ -93,6 +95,19 @@ public class JpaRpcDao extends JpaAbstractDao<RpcEntity, Rpc> implements RpcDao,
         if (queue != null) {
             queue.destroy();
         }
+    }
+
+    @Override
+    public boolean createIfAbsent(TenantId tenantId, Rpc rpc) {
+        RpcEntity entity = new RpcEntity(rpc);
+        if (entity.getCreatedTime() == 0) {
+            // Mirrors JpaAbstractDao.save, which this method replaces on the RPC create path. The device actor
+            // always sets createdTime, but a 0 here would sort the row first forever in loadInFlightRpcs.
+            entity.setCreatedTime(entity.getUuid().version() == 1
+                    ? Uuids.unixTimestamp(entity.getUuid())
+                    : System.currentTimeMillis());
+        }
+        return rpcInsertRepository.save(entity);
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDao.java
@@ -15,7 +15,6 @@
  */
 package org.thingsboard.server.dao.sql.rpc;
 
-import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.google.common.util.concurrent.ListenableFuture;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -99,15 +98,7 @@ public class JpaRpcDao extends JpaAbstractDao<RpcEntity, Rpc> implements RpcDao,
 
     @Override
     public boolean createIfAbsent(TenantId tenantId, Rpc rpc) {
-        RpcEntity entity = new RpcEntity(rpc);
-        if (entity.getCreatedTime() == 0) {
-            // Mirrors JpaAbstractDao.save, which this method replaces on the RPC create path. The device actor
-            // always sets createdTime, but a 0 here would sort the row first forever in loadInFlightRpcs.
-            entity.setCreatedTime(entity.getUuid().version() == 1
-                    ? Uuids.unixTimestamp(entity.getUuid())
-                    : System.currentTimeMillis());
-        }
-        return rpcInsertRepository.save(entity);
+        return rpcInsertRepository.save(new RpcEntity(rpc));
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDao.java
@@ -52,6 +52,10 @@ import java.util.function.Function;
 @RequiredArgsConstructor
 public class JpaRpcDao extends JpaAbstractDao<RpcEntity, Rpc> implements RpcDao, TenantEntityDao<Rpc> {
 
+    private static final String UNSUPPORTED_MERGE =
+            "RPC rows must be written via createIfAbsent(Rpc) or updateAsync(Rpc). The JPA merge is an unguarded " +
+            "upsert: it would clobber the row a previous delivery of the same rpcId created.";
+
     private final RpcRepository rpcRepository;
     private final RpcInsertRepository rpcInsertRepository;
     private final RpcUpdateRepository rpcUpdateRepository;
@@ -97,8 +101,18 @@ public class JpaRpcDao extends JpaAbstractDao<RpcEntity, Rpc> implements RpcDao,
     }
 
     @Override
-    public boolean createIfAbsent(TenantId tenantId, Rpc rpc) {
-        return rpcInsertRepository.save(new RpcEntity(rpc));
+    public boolean createIfAbsent(Rpc rpc) {
+        return rpcInsertRepository.insertIfAbsent(new RpcEntity(rpc));
+    }
+
+    @Override
+    public Rpc save(TenantId tenantId, Rpc rpc) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MERGE);
+    }
+
+    @Override
+    public Rpc saveAndFlush(TenantId tenantId, Rpc rpc) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MERGE);
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcInsertRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcInsertRepository.java
@@ -15,7 +15,6 @@
  */
 package org.thingsboard.server.dao.sql.rpc;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Repository;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.dao.model.sql.RpcEntity;
@@ -45,16 +44,12 @@ public class RpcInsertRepository extends AbstractInsertRepository {
                 rpc.getTenantId(),
                 rpc.getDeviceId(),
                 rpc.getExpirationTime(),
-                toJsonStr(rpc.getRequest()),
-                toJsonStr(rpc.getResponse()),
-                toJsonStr(rpc.getAdditionalInfo()),
+                JacksonUtil.toString(rpc.getRequest()),
+                JacksonUtil.toString(rpc.getResponse()),
+                JacksonUtil.toString(rpc.getAdditionalInfo()),
                 rpc.getStatus().name(),
                 rpc.getRequestId(),
                 rpc.getOneway()) > 0;
-    }
-
-    private String toJsonStr(JsonNode node) {
-        return node == null ? null : replaceNullChars(JacksonUtil.toString(node));
     }
 
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcInsertRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcInsertRepository.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.sql.rpc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.stereotype.Repository;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.dao.model.sql.RpcEntity;
+import org.thingsboard.server.dao.sqlts.insert.AbstractInsertRepository;
+
+@Repository
+public class RpcInsertRepository extends AbstractInsertRepository {
+
+    // The create path must never overwrite an existing row: a re-delivered command has to be a no-op, not a
+    // re-create. This is deliberately STRICTER than the guarded UPDATE in RpcUpdateRepository, which does allow
+    // SENT/TIMEOUT -> QUEUED (the retry re-queue). Do not "unify" the two guards.
+    // DO NOTHING rather than DO UPDATE keeps the hot path free of a row lock, and this single statement replaces
+    // the Hibernate merge's SELECT + INSERT/UPDATE pair.
+    private static final String INSERT_IF_ABSENT =
+            "INSERT INTO rpc (id, created_time, tenant_id, device_id, expiration_time, request, response, " +
+            "additional_info, status, request_id, oneway) " +
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
+            "ON CONFLICT (id) DO NOTHING;";
+
+    // Named save() to match EventInsertRepository / EdgeEventInsertRepository, the codebase's other
+    // ON CONFLICT DO NOTHING repositories. Unlike those two it returns a result: the create path needs to know
+    // whether this was a real insert or a duplicate delivery.
+    boolean save(RpcEntity rpc) {
+        return jdbcTemplate.update(INSERT_IF_ABSENT,
+                rpc.getUuid(),
+                rpc.getCreatedTime(),
+                rpc.getTenantId(),
+                rpc.getDeviceId(),
+                rpc.getExpirationTime(),
+                toJsonStr(rpc.getRequest()),
+                toJsonStr(rpc.getResponse()),
+                toJsonStr(rpc.getAdditionalInfo()),
+                rpc.getStatus().name(),
+                rpc.getRequestId(),
+                rpc.getOneway()) > 0;
+    }
+
+    private String toJsonStr(JsonNode node) {
+        return node == null ? null : replaceNullChars(JacksonUtil.toString(node));
+    }
+
+}

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcInsertRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcInsertRepository.java
@@ -15,13 +15,15 @@
  */
 package org.thingsboard.server.dao.sql.rpc;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.dao.model.sql.RpcEntity;
-import org.thingsboard.server.dao.sqlts.insert.AbstractInsertRepository;
 
 @Repository
-public class RpcInsertRepository extends AbstractInsertRepository {
+@RequiredArgsConstructor
+public class RpcInsertRepository {
 
     private static final String INSERT_IF_ABSENT =
             "INSERT INTO rpc (id, created_time, tenant_id, device_id, expiration_time, request, response, " +
@@ -29,7 +31,9 @@ public class RpcInsertRepository extends AbstractInsertRepository {
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
             "ON CONFLICT (id) DO NOTHING;";
 
-    boolean save(RpcEntity rpc) {
+    private final JdbcTemplate jdbcTemplate;
+
+    boolean insertIfAbsent(RpcEntity rpc) {
         return jdbcTemplate.update(INSERT_IF_ABSENT,
                 rpc.getUuid(),
                 rpc.getCreatedTime(),

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcInsertRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcInsertRepository.java
@@ -23,20 +23,12 @@ import org.thingsboard.server.dao.sqlts.insert.AbstractInsertRepository;
 @Repository
 public class RpcInsertRepository extends AbstractInsertRepository {
 
-    // The create path must never overwrite an existing row: a re-delivered command has to be a no-op, not a
-    // re-create. This is deliberately STRICTER than the guarded UPDATE in RpcUpdateRepository, which does allow
-    // SENT/TIMEOUT -> QUEUED (the retry re-queue). Do not "unify" the two guards.
-    // DO NOTHING rather than DO UPDATE keeps the hot path free of a row lock, and this single statement replaces
-    // the Hibernate merge's SELECT + INSERT/UPDATE pair.
     private static final String INSERT_IF_ABSENT =
             "INSERT INTO rpc (id, created_time, tenant_id, device_id, expiration_time, request, response, " +
             "additional_info, status, request_id, oneway) " +
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) " +
             "ON CONFLICT (id) DO NOTHING;";
 
-    // Named save() to match EventInsertRepository / EdgeEventInsertRepository, the codebase's other
-    // ON CONFLICT DO NOTHING repositories. Unlike those two it returns a result: the create path needs to know
-    // whether this was a real insert or a duplicate delivery.
     boolean save(RpcEntity rpc) {
         return jdbcTemplate.update(INSERT_IF_ABSENT,
                 rpc.getUuid(),

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
@@ -15,12 +15,14 @@
  */
 package org.thingsboard.server.dao.sql.rpc;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.dao.model.sql.RpcEntity;
-import org.thingsboard.server.dao.sqlts.insert.AbstractInsertRepository;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -30,7 +32,8 @@ import java.util.List;
 import java.util.Map;
 
 @Repository
-public class RpcUpdateRepository extends AbstractInsertRepository {
+@RequiredArgsConstructor
+public class RpcUpdateRepository {
 
     private static final String UPDATE =
             "UPDATE rpc SET status = ?, response = COALESCE(?, response) " +
@@ -48,6 +51,9 @@ public class RpcUpdateRepository extends AbstractInsertRepository {
         }
         return byStatus;
     }
+
+    private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate transactionTemplate;
 
     List<Boolean> update(List<RpcEntity> updates) {
         return transactionTemplate.execute(status -> {

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/rpc/RpcUpdateRepository.java
@@ -15,7 +15,6 @@
  */
 package org.thingsboard.server.dao.sql.rpc;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.stereotype.Repository;
 import org.thingsboard.common.util.JacksonUtil;
@@ -57,7 +56,7 @@ public class RpcUpdateRepository extends AbstractInsertRepository {
                 public void setValues(PreparedStatement ps, int i) throws SQLException {
                     RpcEntity rpc = updates.get(i);
                     ps.setString(1, rpc.getStatus().name());
-                    ps.setString(2, toJsonStr(rpc.getResponse()));
+                    ps.setString(2, JacksonUtil.toString(rpc.getResponse()));
                     ps.setObject(3, rpc.getUuid());
                     ps.setArray(4, ps.getConnection().createArrayOf("varchar", allowedFromArray(rpc)));
                 }
@@ -81,7 +80,4 @@ public class RpcUpdateRepository extends AbstractInsertRepository {
         return byStatus.get(rpc.getStatus());
     }
 
-    private String toJsonStr(JsonNode node) {
-        return node == null ? null : replaceNullChars(JacksonUtil.toString(node));
-    }
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/service/TenantServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/TenantServiceTest.java
@@ -606,6 +606,7 @@ public class TenantServiceTest extends AbstractServiceTest {
         // The create path is insert-if-absent and therefore needs the id up front - which is how it is used in
         // production: the device actor builds the Rpc with the rpcId the request already carries.
         Rpc rpc = new Rpc(new RpcId(UUID.randomUUID()));
+        rpc.setCreatedTime(System.currentTimeMillis());
         rpc.setTenantId(tenant.getId());
         rpc.setDeviceId(device.getId());
         rpc.setStatus(RpcStatus.QUEUED);

--- a/dao/src/test/java/org/thingsboard/server/dao/service/TenantServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/TenantServiceTest.java
@@ -611,7 +611,7 @@ public class TenantServiceTest extends AbstractServiceTest {
         rpc.setDeviceId(device.getId());
         rpc.setStatus(RpcStatus.QUEUED);
         rpc.setRequest(JacksonUtil.toJsonNode("{}"));
-        rpcService.create(rpc);
+        assertThat(rpcService.createIfAbsent(rpc)).isTrue();
         return rpc;
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/TenantServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/TenantServiceTest.java
@@ -46,6 +46,7 @@ import org.thingsboard.server.common.data.asset.Asset;
 import org.thingsboard.server.common.data.device.profile.DeviceProfileData;
 import org.thingsboard.server.common.data.device.profile.MqttDeviceProfileTransportConfiguration;
 import org.thingsboard.server.common.data.edge.Edge;
+import org.thingsboard.server.common.data.id.RpcId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.PageLink;
@@ -78,6 +79,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -601,12 +603,15 @@ public class TenantServiceTest extends AbstractServiceTest {
     }
 
     private Rpc createAndSaveRpcFor(Tenant tenant, Device device) {
-        Rpc rpc = new Rpc();
+        // The create path is insert-if-absent and therefore needs the id up front - which is how it is used in
+        // production: the device actor builds the Rpc with the rpcId the request already carries.
+        Rpc rpc = new Rpc(new RpcId(UUID.randomUUID()));
         rpc.setTenantId(tenant.getId());
         rpc.setDeviceId(device.getId());
         rpc.setStatus(RpcStatus.QUEUED);
         rpc.setRequest(JacksonUtil.toJsonNode("{}"));
-        return rpcService.save(rpc);
+        rpcService.create(rpc);
+        return rpc;
     }
 
     private TbResource createAndSaveResourceFor(Tenant tenant) {

--- a/dao/src/test/java/org/thingsboard/server/dao/service/TenantServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/TenantServiceTest.java
@@ -473,7 +473,7 @@ public class TenantServiceTest extends AbstractServiceTest {
         Edge edge = createAndSaveEdgeFor(tenant);
         OtaPackage otaPackage = createAndSaveOtaPackageFor(tenant, deviceProfile);
         TbResource resource = createAndSaveResourceFor(tenant);
-        Rpc rpc = createAndSaveRpcFor(tenant, device);
+        Rpc rpc = createRpcFor(tenant, device);
 
         tenantService.deleteTenant(tenant.getId());
 
@@ -602,7 +602,7 @@ public class TenantServiceTest extends AbstractServiceTest {
         Assert.assertEquals(0, pageDataCustomer.getTotalElements());
     }
 
-    private Rpc createAndSaveRpcFor(Tenant tenant, Device device) {
+    private Rpc createRpcFor(Tenant tenant, Device device) {
         // The create path is insert-if-absent and therefore needs the id up front - which is how it is used in
         // production: the device actor builds the Rpc with the rpcId the request already carries.
         Rpc rpc = new Rpc(new RpcId(UUID.randomUUID()));

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -335,12 +335,12 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
     @Test
     public void findInFlightForReloadExcludesOneWayDeliveredAndTerminal() {
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
-        UUID q = saveRpc(deviceId, RpcStatus.QUEUED, false);
-        UUID s = saveRpc(deviceId, RpcStatus.SENT, true);          // one-way SENT still reloaded (retry)
-        UUID t = saveRpc(deviceId, RpcStatus.TIMEOUT, false);      // delivery ack timed out -> in-flight, reloaded
-        UUID twoWayDel = saveRpc(deviceId, RpcStatus.DELIVERED, false);
-        saveRpc(deviceId, RpcStatus.DELIVERED, true);              // one-way DELIVERED -> excluded
-        saveRpc(deviceId, RpcStatus.SUCCESSFUL, false);            // terminal -> excluded
+        UUID q = seedRpc(deviceId, RpcStatus.QUEUED, false);
+        UUID s = seedRpc(deviceId, RpcStatus.SENT, true);          // one-way SENT still reloaded (retry)
+        UUID t = seedRpc(deviceId, RpcStatus.TIMEOUT, false);      // delivery ack timed out -> in-flight, reloaded
+        UUID twoWayDel = seedRpc(deviceId, RpcStatus.DELIVERED, false);
+        seedRpc(deviceId, RpcStatus.DELIVERED, true);              // one-way DELIVERED -> excluded
+        seedRpc(deviceId, RpcStatus.SUCCESSFUL, false);            // terminal -> excluded
 
         List<UUID> got = rpcDao.findInFlightForReload(TenantId.SYS_TENANT_ID, deviceId, new PageLink(100))
                 .getData().stream().map(Rpc::getUuidId).toList();
@@ -367,13 +367,13 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         assertThat(stored.getResponse()).isEqualTo(JacksonUtil.toJsonNode("{\"ok\":true}"));
     }
 
-    private UUID saveRpc(DeviceId deviceId, RpcStatus status, boolean oneway) {
+    private UUID seedRpc(DeviceId deviceId, RpcStatus status, boolean oneway) {
         UUID id = UUID.randomUUID();
-        Rpc toSave = rpc(id, deviceId, status, null);
-        toSave.setOneway(oneway);
-        toSave.setRequestId(null);
-        toSave.setExpirationTime(System.currentTimeMillis() + 60_000);
-        rpcDao.createIfAbsent(toSave);
+        Rpc toCreate = rpc(id, deviceId, status, null);
+        toCreate.setOneway(oneway);
+        toCreate.setRequestId(null);
+        toCreate.setExpirationTime(System.currentTimeMillis() + 60_000);
+        rpcDao.createIfAbsent(toCreate);
         return id;
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class JpaRpcDaoTest extends AbstractJpaDaoTest {
 
@@ -59,26 +60,21 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
 
     @Test
     public void deleteOutdated() {
-        Rpc rpc = new Rpc();
-        rpc.setTenantId(TenantId.SYS_TENANT_ID);
-        rpc.setDeviceId(new DeviceId(UUID.randomUUID()));
-        rpc.setStatus(RpcStatus.QUEUED);
-        rpc.setRequest(JacksonUtil.toJsonNode("{}"));
-        rpcDao.saveAndFlush(rpc.getTenantId(), rpc);
+        // Dedicated tenants, NOT SYS_TENANT_ID: the Long.MAX_VALUE case deletes every row of the tenant it is
+        // given, and this class has no per-test rollback, so sharing a tenant with the other tests would make
+        // the exact counts below depend on JUnit's method ordering.
+        TenantId tenantId = TenantId.fromUUID(UUID.randomUUID());
+        TenantId otherTenantId = TenantId.fromUUID(UUID.randomUUID());
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
 
-        rpc.setId(null);
-        rpcDao.saveAndFlush(rpc.getTenantId(), rpc);
-
-        TenantId tenantId = TenantId.fromUUID(UUID.fromString("3d193a7a-774b-4c05-84d5-f7fdcf7a37cf"));
-        rpc.setId(null);
-        rpc.setTenantId(tenantId);
-        rpc.setDeviceId(new DeviceId(UUID.randomUUID()));
-        rpcDao.saveAndFlush(rpc.getTenantId(), rpc);
+        rpcDao.createIfAbsent(rpc(tenantId, UUID.randomUUID(), deviceId, RpcStatus.QUEUED, null));
+        rpcDao.createIfAbsent(rpc(tenantId, UUID.randomUUID(), deviceId, RpcStatus.QUEUED, null));
+        rpcDao.createIfAbsent(rpc(otherTenantId, UUID.randomUUID(), new DeviceId(UUID.randomUUID()), RpcStatus.QUEUED, null));
 
         int batchSize = 10_000;
-        assertThat(rpcDao.deleteOutdatedRpcByTenantIdBatch(TenantId.SYS_TENANT_ID, 0L, batchSize)).isEqualTo(0);
-        assertThat(rpcDao.deleteOutdatedRpcByTenantIdBatch(TenantId.SYS_TENANT_ID, Long.MAX_VALUE, batchSize)).isEqualTo(2);
-        assertThat(rpcDao.deleteOutdatedRpcByTenantIdBatch(tenantId, System.currentTimeMillis() + 1, batchSize)).isEqualTo(1);
+        assertThat(rpcDao.deleteOutdatedRpcByTenantIdBatch(tenantId, 0L, batchSize)).isEqualTo(0);
+        assertThat(rpcDao.deleteOutdatedRpcByTenantIdBatch(tenantId, Long.MAX_VALUE, batchSize)).isEqualTo(2);
+        assertThat(rpcDao.deleteOutdatedRpcByTenantIdBatch(otherTenantId, System.currentTimeMillis() + 1, batchSize)).isEqualTo(1);
     }
 
     @Test
@@ -87,7 +83,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
 
         // Production create path: the QUEUED row is persisted synchronously (persist-before-send).
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(id, deviceId, RpcStatus.QUEUED, null));
+        rpcDao.createIfAbsent(rpc(id, deviceId, RpcStatus.QUEUED, null));
 
         Rpc stored = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
         assertThat(stored).isNotNull();
@@ -110,7 +106,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         UUID idB = UUID.randomUUID(); // never created -> its update must report no match
 
         // Row A exists (persisted synchronously at create time); B was never created.
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(idA, deviceId, RpcStatus.QUEUED, null));
+        rpcDao.createIfAbsent(rpc(idA, deviceId, RpcStatus.QUEUED, null));
 
         // Drive the persist logic directly with a single, deterministically-coalesced update batch.
         // This is exactly what "coalescing" means: one update() call carrying several writes for the
@@ -146,7 +142,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
 
         // Initial create.
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(id, deviceId, RpcStatus.QUEUED, null));
+        rpcDao.createIfAbsent(rpc(id, deviceId, RpcStatus.QUEUED, null));
 
         // Delivery timeout with closeTransportSessionOnRpcDeliveryTimeout=true re-queues the RPC: the
         // device actor persists status=QUEUED again as a status update so init() can re-pick it up.
@@ -163,7 +159,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         UUID id = UUID.randomUUID();
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
 
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(id, deviceId, RpcStatus.QUEUED, null));
+        rpcDao.createIfAbsent(rpc(id, deviceId, RpcStatus.QUEUED, null));
 
         // A real device response reaches SUCCESSFUL with a response body.
         assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.SUCCESSFUL, JacksonUtil.toJsonNode("{\"ok\":true}")))
@@ -183,7 +179,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
         Rpc created = rpc(id, deviceId, RpcStatus.DELIVERED, null);
         created.setOneway(true);
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, created);
+        rpcDao.createIfAbsent(created);
 
         // One-way DELIVERED is terminal. A one-way write carries oneway=true (as the actor sets from the request),
         // so its allowed-from set excludes DELIVERED and the guard blocks the overwrite.
@@ -199,7 +195,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
         Rpc created = rpc(id, deviceId, RpcStatus.DELIVERED, null);
         created.setOneway(false);
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, created);
+        rpcDao.createIfAbsent(created);
 
         // Two-way DELIVERED is in-flight (awaiting response), so a genuine timeout may expire it.
         Rpc expired = rpc(id, deviceId, RpcStatus.EXPIRED, null);
@@ -212,7 +208,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
     public void guardAllowsSuccessfulFromSent() throws Exception {
         UUID id = UUID.randomUUID();
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(id, deviceId, RpcStatus.SENT, null));
+        rpcDao.createIfAbsent(rpc(id, deviceId, RpcStatus.SENT, null));
 
         // Response for an as-yet-undelivered RPC (no PUBACK) lands while status is still SENT.
         assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.SUCCESSFUL, JacksonUtil.toJsonNode("{\"v\":1}")))
@@ -228,7 +224,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
         Rpc created = rpc(id, deviceId, RpcStatus.DELIVERED, null);
         created.setOneway(false);
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, created);
+        rpcDao.createIfAbsent(created);
 
         // A stale/duplicate SENT must not roll DELIVERED backwards.
         assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.SENT, null)).get(5, TimeUnit.SECONDS)).isFalse();
@@ -240,7 +236,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         UUID id = UUID.randomUUID();
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
 
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, rpc(id, deviceId, RpcStatus.QUEUED, null));
+        rpcDao.createIfAbsent(rpc(id, deviceId, RpcStatus.QUEUED, null));
 
         // RPC is removed (TTL cleanup / manual delete) while a response is still in flight.
         rpcDao.removeById(TenantId.SYS_TENANT_ID, id);
@@ -263,7 +259,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         toCreate.setOneway(true);
         toCreate.setAdditionalInfo(JacksonUtil.toJsonNode("{\"src\":\"test\"}"));
 
-        assertThat(rpcDao.createIfAbsent(TenantId.SYS_TENANT_ID, toCreate)).isTrue();
+        assertThat(rpcDao.createIfAbsent(toCreate)).isTrue();
 
         // Every column the native INSERT binds must round-trip - a missed column would silently write NULL.
         Rpc stored = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
@@ -280,19 +276,36 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
     }
 
     @Test
+    public void saveIsUnsupportedSoTheUnguardedMergeStaysUnreachable() {
+        UUID id = UUID.randomUUID();
+        Rpc toSave = rpc(id, new DeviceId(UUID.randomUUID()), RpcStatus.QUEUED, null);
+
+        // The JPA merge is the bug this whole path replaces: it would upsert, clobbering a row an earlier
+        // delivery of the same rpcId created. Both entry points must stay closed - saveAndFlush does NOT
+        // delegate to the public save(), so overriding one would not cover the other.
+        assertThatThrownBy(() -> rpcDao.save(TenantId.SYS_TENANT_ID, toSave))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, toSave))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        // ...and neither attempt wrote anything.
+        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, id)).isNull();
+    }
+
+    @Test
     public void createIfAbsentIsNoOpWhenRowExists() {
         UUID id = UUID.randomUUID();
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
         Rpc original = rpc(id, deviceId, RpcStatus.QUEUED, null);
         original.setRequestId(1);
-        assertThat(rpcDao.createIfAbsent(TenantId.SYS_TENANT_ID, original)).isTrue();
+        assertThat(rpcDao.createIfAbsent(original)).isTrue();
 
         // A re-delivered command carries the SAME rpcId but a fresh rpcSeq and a later createdTime.
         // The old JPA merge overwrote both; insert-if-absent must change nothing at all.
         Rpc duplicate = rpc(id, deviceId, RpcStatus.QUEUED, null);
         duplicate.setRequestId(99);
         duplicate.setCreatedTime(original.getCreatedTime() + 5_000);
-        assertThat(rpcDao.createIfAbsent(TenantId.SYS_TENANT_ID, duplicate)).isFalse();
+        assertThat(rpcDao.createIfAbsent(duplicate)).isFalse();
 
         Rpc stored = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
         assertThat(stored.getRequestId()).isEqualTo(1);
@@ -304,7 +317,7 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
     public void createIfAbsentDoesNotResurrectTerminalRow() throws Exception {
         UUID id = UUID.randomUUID();
         DeviceId deviceId = new DeviceId(UUID.randomUUID());
-        assertThat(rpcDao.createIfAbsent(TenantId.SYS_TENANT_ID, rpc(id, deviceId, RpcStatus.QUEUED, null))).isTrue();
+        assertThat(rpcDao.createIfAbsent(rpc(id, deviceId, RpcStatus.QUEUED, null))).isTrue();
 
         // The two write paths compose: insert-if-absent creates, the guarded UPDATE completes.
         assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.SUCCESSFUL, JacksonUtil.toJsonNode("{\"ok\":true}")))
@@ -312,32 +325,11 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
 
         // The reported bug: a re-delivered create used to merge the finished row back to QUEUED with a new
         // requestId, producing a second in-flight attempt against one row.
-        assertThat(rpcDao.createIfAbsent(TenantId.SYS_TENANT_ID, rpc(id, deviceId, RpcStatus.QUEUED, null))).isFalse();
+        assertThat(rpcDao.createIfAbsent(rpc(id, deviceId, RpcStatus.QUEUED, null))).isFalse();
 
         Rpc stored = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
         assertThat(stored.getStatus()).isEqualTo(RpcStatus.SUCCESSFUL);
         assertThat(stored.getResponse()).isEqualTo(JacksonUtil.toJsonNode("{\"ok\":true}"));
-    }
-
-    @Test
-    public void requestIdRoundTripsThroughSaveAndLoad() {
-        UUID id = UUID.randomUUID();
-        DeviceId deviceId = new DeviceId(UUID.randomUUID());
-        Rpc toSave = rpc(id, deviceId, RpcStatus.SENT, null);
-        toSave.setRequestId(42);
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, toSave);
-
-        Rpc loaded = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
-        assertThat(loaded.getRequestId()).isEqualTo(42);
-    }
-
-    @Test
-    public void onewayRoundTripsThroughSaveAndLoad() {
-        UUID id = UUID.randomUUID();
-        Rpc toSave = rpc(id, new DeviceId(UUID.randomUUID()), RpcStatus.SENT, null);
-        toSave.setOneway(true);
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, toSave);
-        assertThat(rpcDao.findById(TenantId.SYS_TENANT_ID, id).getOneway()).isTrue();
     }
 
     @Test
@@ -381,14 +373,18 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
         toSave.setOneway(oneway);
         toSave.setRequestId(null);
         toSave.setExpirationTime(System.currentTimeMillis() + 60_000);
-        rpcDao.saveAndFlush(TenantId.SYS_TENANT_ID, toSave);
+        rpcDao.createIfAbsent(toSave);
         return id;
     }
 
     private Rpc rpc(UUID id, DeviceId deviceId, RpcStatus status, JsonNode response) {
+        return rpc(TenantId.SYS_TENANT_ID, id, deviceId, status, response);
+    }
+
+    private Rpc rpc(TenantId tenantId, UUID id, DeviceId deviceId, RpcStatus status, JsonNode response) {
         Rpc rpc = new Rpc(new RpcId(id));
         rpc.setCreatedTime(System.currentTimeMillis());
-        rpc.setTenantId(TenantId.SYS_TENANT_ID);
+        rpc.setTenantId(tenantId);
         rpc.setDeviceId(deviceId);
         rpc.setExpirationTime(System.currentTimeMillis() + 60_000);
         rpc.setRequest(JacksonUtil.toJsonNode("{\"method\":\"x\"}"));

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/rpc/JpaRpcDaoTest.java
@@ -255,6 +255,71 @@ public class JpaRpcDaoTest extends AbstractJpaDaoTest {
     }
 
     @Test
+    public void createIfAbsentInsertsWhenRowMissing() {
+        UUID id = UUID.randomUUID();
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        Rpc toCreate = rpc(id, deviceId, RpcStatus.QUEUED, null);
+        toCreate.setRequestId(3);
+        toCreate.setOneway(true);
+        toCreate.setAdditionalInfo(JacksonUtil.toJsonNode("{\"src\":\"test\"}"));
+
+        assertThat(rpcDao.createIfAbsent(TenantId.SYS_TENANT_ID, toCreate)).isTrue();
+
+        // Every column the native INSERT binds must round-trip - a missed column would silently write NULL.
+        Rpc stored = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
+        assertThat(stored).isNotNull();
+        assertThat(stored.getStatus()).isEqualTo(RpcStatus.QUEUED);
+        assertThat(stored.getRequestId()).isEqualTo(3);
+        assertThat(stored.getOneway()).isTrue();
+        assertThat(stored.getCreatedTime()).isEqualTo(toCreate.getCreatedTime());
+        assertThat(stored.getExpirationTime()).isEqualTo(toCreate.getExpirationTime());
+        assertThat(stored.getDeviceId()).isEqualTo(deviceId);
+        assertThat(stored.getRequest()).isEqualTo(JacksonUtil.toJsonNode("{\"method\":\"x\"}"));
+        assertThat(stored.getAdditionalInfo()).isEqualTo(JacksonUtil.toJsonNode("{\"src\":\"test\"}"));
+        assertThat(stored.getResponse()).isNull();
+    }
+
+    @Test
+    public void createIfAbsentIsNoOpWhenRowExists() {
+        UUID id = UUID.randomUUID();
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        Rpc original = rpc(id, deviceId, RpcStatus.QUEUED, null);
+        original.setRequestId(1);
+        assertThat(rpcDao.createIfAbsent(TenantId.SYS_TENANT_ID, original)).isTrue();
+
+        // A re-delivered command carries the SAME rpcId but a fresh rpcSeq and a later createdTime.
+        // The old JPA merge overwrote both; insert-if-absent must change nothing at all.
+        Rpc duplicate = rpc(id, deviceId, RpcStatus.QUEUED, null);
+        duplicate.setRequestId(99);
+        duplicate.setCreatedTime(original.getCreatedTime() + 5_000);
+        assertThat(rpcDao.createIfAbsent(TenantId.SYS_TENANT_ID, duplicate)).isFalse();
+
+        Rpc stored = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
+        assertThat(stored.getRequestId()).isEqualTo(1);
+        assertThat(stored.getCreatedTime()).isEqualTo(original.getCreatedTime());
+        assertThat(stored.getStatus()).isEqualTo(RpcStatus.QUEUED);
+    }
+
+    @Test
+    public void createIfAbsentDoesNotResurrectTerminalRow() throws Exception {
+        UUID id = UUID.randomUUID();
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        assertThat(rpcDao.createIfAbsent(TenantId.SYS_TENANT_ID, rpc(id, deviceId, RpcStatus.QUEUED, null))).isTrue();
+
+        // The two write paths compose: insert-if-absent creates, the guarded UPDATE completes.
+        assertThat(rpcDao.updateAsync(rpc(id, deviceId, RpcStatus.SUCCESSFUL, JacksonUtil.toJsonNode("{\"ok\":true}")))
+                .get(5, TimeUnit.SECONDS)).isTrue();
+
+        // The reported bug: a re-delivered create used to merge the finished row back to QUEUED with a new
+        // requestId, producing a second in-flight attempt against one row.
+        assertThat(rpcDao.createIfAbsent(TenantId.SYS_TENANT_ID, rpc(id, deviceId, RpcStatus.QUEUED, null))).isFalse();
+
+        Rpc stored = rpcDao.findById(TenantId.SYS_TENANT_ID, id);
+        assertThat(stored.getStatus()).isEqualTo(RpcStatus.SUCCESSFUL);
+        assertThat(stored.getResponse()).isEqualTo(JacksonUtil.toJsonNode("{\"ok\":true}"));
+    }
+
+    @Test
     public void requestIdRoundTripsThroughSaveAndLoad() {
         UUID id = UUID.randomUUID();
         DeviceId deviceId = new DeviceId(UUID.randomUUID());


### PR DESCRIPTION
## Problem

The persistent-RPC status-update path is guarded (`UPDATE … WHERE id = ? AND status = ANY(<allowed-from>)`), but the create path is not: the `Rpc` is built with a preset id, so `JpaAbstractDao.save` takes the `isNew == false` branch — a JPA merge, i.e. an unconditional upsert.

So a re-delivered command (a rule engine partition re-consumed before it was acknowledged, or a retry processing strategy) clobbers the existing row back to `QUEUED` with a fresh `requestId`, registers a second pending entry under a new `rpcSeq`, and re-sends to the device. Two in-flight attempts against one row, a non-deterministic final status, and a duplicate delivery. The guarded UPDATE can't help — the damage is done by the create.

## Goal

Make a re-delivered persistent RPC a no-op, so at-least-once delivery is safe on the create path.

## Approach

- **DAO** — new `RpcInsertRepository.insertIfAbsent(RpcEntity)` doing `INSERT … ON CONFLICT (id) DO NOTHING`, returning whether a row was inserted. One statement replaces the merge's `SELECT` + `INSERT`/`UPDATE` pair.
- **`RpcService.save(Rpc)` → `boolean createIfAbsent(Rpc)`**, so the unguarded upsert is no longer reachable from the service API. `RpcDao` gains `createIfAbsent(Rpc)` — the tenant comes off the `Rpc` itself, matching the sibling `updateAsync(Rpc)`.
- **`TbRpcService.createIfAbsent`** returns `inserted` and notifies the rule engine only when it actually inserted, so a duplicate emits no spurious `RPC_QUEUED`.
- **`processRpcRequest`** — on a collision, skip the device send and `registerPendingRpcRequest` and return. The existing row's own lifecycle (live pending entry, or the reload on actor init) owns delivery.
- **`JpaRpcDao.save` / `saveAndFlush` now throw `UnsupportedOperationException`.** With no callers left, the merge was still one call away from coming back via `Dao<T>`. Both need overriding: `JpaAbstractDao.saveAndFlush` delegates to a private `save(tenantId, domain, flush)` overload rather than to the public `save`, so covering one would leave the other live. Enforcement is runtime-only — making it a compile error would mean splitting `Dao<T>` for every entity type. The generic `Dao<?>` consumers that can reach this DAO through `EntityDaoRegistry` (`uniquifyEntityName`, `EdqsSyncService`, `TenantEntitiesDeletionTaskProcessor`, `BaseEdgeProcessor`, `DefaultExportableEntitiesService`) all only read.

The create guard is deliberately stricter than the update guard and the two must stay separate: `RpcStatus.QUEUED.getAllowedFromStatuses()` is `{SENT, TIMEOUT}`, so a re-queue *is* a legal update. Only create requires plain absence.

No proto / wire / transport / device change.

**Behavior change:** every persisted RPC now returns its `rpcId`, including one that arrived already expired. That branch previously wrote the `EXPIRED` row and returned silently, so the caller waited out the core's safety net for an opaque `TIMEOUT` and never learned the id. Bounded by the same 1 s grace window — past it the reply is discarded as stale, as before.

**Caveat:** this is dedup-by-id, so it only applies when the re-delivered command carries the same id. `TbSendRPCRequestNode` mints `Uuids.timeBased()` when the metadata has no `requestUUID`, and never writes it back — a rule chain relying on that fallback is not re-delivery-safe. Documenting it in `nodeDetails` belongs to #36.

## Tests

`JpaRpcDaoTest` covers the DB-level semantics against real Postgres: the insert round-trips every bound column, a duplicate leaves `request_id` / `created_time` / `status` untouched, a duplicate against a row already driven to `SUCCESSFUL` neither resurrects it nor drops the response, and both `save` entry points throw without writing a row. Its fixtures seed through `createIfAbsent` rather than the JPA merge, so the guard and update tests assert against rows shaped the way production shapes them.

`TbRpcServiceTest` asserts no rule-engine message on a collision. `DeviceActorMessageProcessorTest` covers the duplicate skipping both the send and the pending registration while still replying with the `rpcId`, the expired-on-arrival reply, and a first delivery behaving exactly as before.

**Not covered:** there is no end-to-end test composing the actor branch with the real DAO — the actor tests stub `TbRpcService`, and `JpaRpcDaoTest` has no actor. A second delivery of the same `rpcId` producing exactly one row and one device publish is verified only as two separately-mocked halves.
